### PR TITLE
java11

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: clair
 Bundle-SymbolicName: clair;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.cdt.core;bundle-version="6.11.0",
- rascal_eclipse;bundle-version="0.23.0"
+Require-Bundle: org.eclipse.cdt.core,
+ org.eclipse.core.runtime,
+ rascal_eclipse
 Automatic-Module-Name: clair

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,14 @@
 		<developerConnection>scm:git:https://github.com/cwi-swat/clair.git</developerConnection>			
 	</scm>
 
+        <repositories>
+            <!--to find the pom-parent-->
+            <repository>
+                <id>releases</id>
+                <name>usethesource.io releases</name>
+                <url>https://releases.usethesource.io/maven</url>
+            </repository>
+        </repositories>
 	
         <build>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.usethesource</groupId>
 		<artifactId>pom_parent</artifactId>
-		<version>0.5.0</version>
+		<version>0.5.2</version>
 	</parent>
 
 	<artifactId>clair</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.usethesource</groupId>
 		<artifactId>pom_parent</artifactId>
-		<version>0.5.2</version>
+		<version>0.6.0</version>
 	</parent>
 
 	<artifactId>clair</artifactId>
@@ -17,54 +17,56 @@
 		<developerConnection>scm:git:https://github.com/cwi-swat/clair.git</developerConnection>			
 	</scm>
 
-  <repositories>  
-    <repository>
-      <id>releases</id>
-      <name>usethesource.io releases</name>
-      <url>https://releases.usethesource.io/maven</url>
-    </repository>
-  </repositories>  
 	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.rascalmpl</groupId>
-				<artifactId>rascal-maven-plugin</artifactId>
-				<version>0.2.17</version>
-				<configuration>
-					<errorsAsWarnings>false</errorsAsWarnings>
-					<bin>${project.build.outputDirectory}</bin>
-					<srcs>
-						<src>${project.basedir}/src</src>
-					</srcs>
-					<sourceLookup>|lib://clair/|</sourceLookup>
-					<srcIgnores>
-						<ignore>${project.basedir}/src/lang/cpp/SConcrete.rsc</ignore>
-						<ignore>${project.basedir}/src/lang/cpp/ST.rsc</ignore>
-						<ignore>${project.basedir}/src/lang/cpp/Test.rsc</ignore>
-						<ignore>${project.basedir}/src/lang/cpp/IDE.rsc</ignore>
-						<ignore>${project.basedir}/src/SLEPaper.rsc</ignore>
-						<ignore>${project.basedir}/src/test</ignore>
-					</srcIgnores>
-					<enableStandardLibrary>true</enableStandardLibrary>
-				</configuration>
-				<executions>
-					<execution>
-						<id>it-compile</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>it-package</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>package</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-</project>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <compilerArgument>-parameters</compilerArgument> <!-- make sure parameters are compiled by name into the jar -->
+                        <release>11</release>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.rascalmpl</groupId>
+                    <artifactId>rascal-maven-plugin</artifactId>
+                    <version>0.2.17</version>
+                    <configuration>
+                        <errorsAsWarnings>false</errorsAsWarnings>
+                        <bin>${project.build.outputDirectory}</bin>
+                        <srcs>
+                            <src>${project.basedir}/src</src>
+                        </srcs>
+                        <sourceLookup>|lib://clair/|</sourceLookup>
+                        <srcIgnores>
+                            <ignore>${project.basedir}/src/lang/cpp/SConcrete.rsc</ignore>
+                            <ignore>${project.basedir}/src/lang/cpp/ST.rsc</ignore>
+                            <ignore>${project.basedir}/src/lang/cpp/Test.rsc</ignore>
+                            <ignore>${project.basedir}/src/lang/cpp/IDE.rsc</ignore>
+                            <ignore>${project.basedir}/src/SLEPaper.rsc</ignore>
+                            <ignore>${project.basedir}/src/test</ignore>
+                        </srcIgnores>
+                        <enableStandardLibrary>true</enableStandardLibrary>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>it-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>it-package</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </project>

--- a/src/lang/cpp/AST.rsc
+++ b/src/lang/cpp/AST.rsc
@@ -448,26 +448,20 @@ public map[str, list[loc]] classPaths = (
     );
 
 @javaClass{lang.cpp.internal.Parser}  
-@reflect{need access to streams}   
 java Declaration parseCpp(loc file, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 @javaClass{lang.cpp.internal.Parser}  
-@reflect{need access to streams}   
 java list[Declaration] parseFiles(list[loc] files, list[loc] stdLib = classPaths["vs12"], list[loc] includeDirs = [], map[str,str] additionalMacros = (), bool includeStdLib = false);
 
 @javaClass{lang.cpp.internal.Parser}  
-@reflect{need access to streams}   
 java Declaration parseString(str code);
 
 @javaClass{lang.cpp.internal.Parser}  
-@reflect{need access to streams}   
 java Declaration parseString(str code, loc l);
 
 @javaClass{lang.cpp.internal.Parser}
-@reflect{need access to streams}
 java list[loc] parseForComments(loc file, list[loc] includePaths = classPaths["vs12"], map[str,str] additionalMacros = ());
 
 @javaClass{lang.cpp.internal.Parser}
-@reflect{need access to streams}
 java rel[loc,loc] parseForMacros(loc file, list[loc] includePaths = classPaths["vs12"], map[str,str] additionalMacros = ());
 

--- a/src/lang/cpp/internal/Parser.java
+++ b/src/lang/cpp/internal/Parser.java
@@ -13,6 +13,7 @@
 package lang.cpp.internal;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -198,8 +199,8 @@ import org.eclipse.cdt.internal.core.dom.parser.IASTAmbiguousStatement;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTCompoundStatementExpression;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ClassTypeHelper;
 import org.eclipse.core.runtime.CoreException;
-import org.rascalmpl.interpreter.IEvaluatorContext;
-import org.rascalmpl.interpreter.utils.RuntimeExceptionFactory;
+import org.rascalmpl.debug.IRascalMonitor;
+import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.uri.URIUtil;
 
 import io.usethesource.vallang.IBool;
@@ -220,3201 +221,3194 @@ import io.usethesource.vallang.io.StandardTextReader;
 
 @SuppressWarnings("restriction")
 public class Parser extends ASTVisitor {
-	private IValueFactory vf;
-	private AST builder;
-	private IEvaluatorContext ctx;
-	private Stack<IConstructor> stack = new Stack<>();
-	private BindingsResolver br = new BindingsResolver();
-	private TypeResolver tr;
-
-	private boolean doProblemLogging = false;
-	private boolean toM3 = false;
-	private boolean includeStdLib = false;
-	private IList stdLib;
-
-	private ISetWriter declaredType;
-
-	public Parser(IValueFactory vf) {
-		super(true);
-		this.shouldVisitAmbiguousNodes = true;
-		this.shouldVisitImplicitNames = true;
-		this.includeInactiveNodes = true;
-		this.shouldVisitTokens = true;
-
-		this.vf = vf;
-		this.builder = new AST(vf);
-		this.tr = new TypeResolver(builder, vf);
-		this.declaredType = vf.setWriter();
-	}
-
-	public IList parseFiles(IList files, IList stdLib, IList includeDirs, IMap additionalMacros, IBool includeStdLib,
-			IEvaluatorContext ctx) {
-		setIEvaluatorContext(ctx);
-		this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
-		this.stdLib = stdLib;
-
-		CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), ctx);
-		Instant begin = Instant.now();
-		out("Beginning at " + begin.toString());
-		IListWriter asts = vf.listWriter();
-		for (IValue v : files) {
-			if (ctx.isInterrupted()) {
-				break;
-			}
-			ISourceLocation file = (ISourceLocation) v;
-			IASTTranslationUnit tu = parser.parseFile(file);
-			IValue result = convertCdtToRascal(tu, false);
-			asts.append(result);
-		}
-		Instant done = Instant.now();
-		out("Parsing and marshalling " + files.size() + " files took "
-				+ new Double(Duration.between(begin, done).toMillis()).doubleValue() / 1000 + "seconds");
-		return asts.done();
-	}
-
-	public IValue parseCpp(ISourceLocation file, IList stdLib, IList includeDirs, IMap additionalMacros,
-			IBool includeStdLib, IEvaluatorContext ctx) {
-		setIEvaluatorContext(ctx);
-		this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
-		this.stdLib = stdLib;
-
-		Instant begin = Instant.now();
-		out("Beginning at " + begin.toString());
-		CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), ctx);
-		IASTTranslationUnit tu = parser.parseFile(file);
-		Instant between = Instant.now();
-		out("CDT took " + new Double(Duration.between(begin, between).toMillis()).doubleValue() / 1000 + "seconds");
-		IValue result = convertCdtToRascal(tu, false);
-		Instant done = Instant.now();
-		out("Marshalling took " + new Double(Duration.between(between, done).toMillis()).doubleValue() / 1000
-				+ "seconds");
-		if (result == null) {
-			throw RuntimeExceptionFactory.parseError(file, null, null);
-		}
-		return result;
-	}
-
-	public ITuple parseCppToM3AndAst(ISourceLocation file, IList stdLib, IList includeDirs, IMap additionalMacros,
-			IBool includeStdLib, IEvaluatorContext ctx) {
-		setIEvaluatorContext(ctx);
-		this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
-		this.stdLib = stdLib;
-
-		IValue m3 = builder.M3_m3(file);
-		CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), ctx);
-		IASTTranslationUnit tu = parser.parseFile(file);
-		IList comments = getCommentsFromTranslationUnit(tu);
-		ISet macroExpansions = getMacroExpansionsFromTranslationUnit(tu);
-		ISet macroDefinitions = getMacroDefinitionsFromTranslationUnit(tu);
-		ISet methodOverrides = getMethodOverrides(tu);
-
-		m3 = m3.asWithKeywordParameters().setParameter("comments", comments);
-		m3 = m3.asWithKeywordParameters().setParameter("macroExpansions", macroExpansions);
-		m3 = m3.asWithKeywordParameters().setParameter("macroDefinitions", macroDefinitions);
-		m3 = m3.asWithKeywordParameters().setParameter("methodOverrides", methodOverrides);
-		m3 = setM3IncludeInformationFromTranslationUnit(tu, m3);
-
-		declaredType = vf.setWriter();
-		IValue result = convertCdtToRascal(tu, true);
-		m3 = m3.asWithKeywordParameters().setParameter("declaredType", declaredType.done());
-
-		return vf.tuple(m3, result);
-	}
-
-	public ISet getMethodOverrides(IASTTranslationUnit tu) {
-		NameCollector anc = new NameCollector();
-		tu.accept(anc);
-		Set<IBinding> bindings = new HashSet<>();
-		Stream.of(anc.getNames()).forEach(it -> bindings.add(it.resolveBinding()));
-		ISetWriter methodOverrides = vf.setWriter();
-		bindings.stream().filter(ICPPMethod.class::isInstance).forEach(override -> {
-			Stream.of(ClassTypeHelper.findOverridden((ICPPMethod) override)).forEach(base -> {
-				try {
-					methodOverrides.insert(vf.tuple(br.resolveBinding(base), br.resolveBinding(override)));
-				} catch (FactTypeUseException | URISyntaxException e) {
-					err("Got FactTypeUseException\n" + e.getMessage());
-				}
-			});
-		});
-		return methodOverrides.done();
-	}
-
-	public ISet getMacroDefinitionsFromTranslationUnit(IASTTranslationUnit tu) {
-		return Stream.of(tu.getMacroDefinitions()).map(it -> {
-			try {
-				return vf.tuple(br.resolveBinding(it.getName().resolveBinding()), getSourceLocation(it));
-			} catch (URISyntaxException e) {
-				return vf.tuple(vf.sourceLocation(URIUtil.rootScheme("unknown")), getSourceLocation(it));
-			}
-		}).collect(vf.setWriter());
-	}
-
-	public IList getCommentsFromTranslationUnit(IASTTranslationUnit tu) {
-		return Stream.of(tu.getComments()).map(this::getSourceLocation).collect(vf.listWriter());
-	}
-
-	public IList parseForComments(ISourceLocation file, IList includePath, IMap additionalMacros,
-			IEvaluatorContext ctx) {
-		setIEvaluatorContext(ctx);
-		CDTParser parser = new CDTParser(vf.listWriter().done(), includePath, additionalMacros, true, ctx);
-		IASTTranslationUnit tu = parser.parseFile(file);
-		return getCommentsFromTranslationUnit(tu);
-	}
-
-	public IValue setM3IncludeInformationFromTranslationUnit(IASTTranslationUnit tu, IValue m3) {
-		ISetWriter includeDirectives = vf.setWriter();
-		ISetWriter inactiveIncludes = vf.setWriter();
-		ISetWriter includeResolution = vf.setWriter();
-		Stream.of(tu.getIncludeDirectives()).forEach(it -> {
-			ISourceLocation include = vf.sourceLocation(URIUtil.rootScheme("unknown"));
-			try {
-				include = vf.sourceLocation(it.isSystemInclude() ? "cpp+systemInclude" : "cpp+include", null,
-						it.getName().toString());
-			} catch (URISyntaxException e) {
-				// Shouldn't happen
-			}
-			if (it.isActive())
-				includeDirectives.insert(vf.tuple(include, getSourceLocation(it)));
-			else
-				inactiveIncludes.insert(vf.tuple(include, getSourceLocation(it)));
-			ISourceLocation path = "" == it.getPath() ? vf.sourceLocation(URIUtil.rootScheme("unresolved"))
-					: vf.sourceLocation(it.getPath());
-			includeResolution.insert(vf.tuple(include, path));
-		});
-
-		m3 = m3.asWithKeywordParameters().setParameter("includeDirectives", includeDirectives.done());
-		m3 = m3.asWithKeywordParameters().setParameter("inactiveIncludes", inactiveIncludes.done());
-		m3 = m3.asWithKeywordParameters().setParameter("includeResolution", includeResolution.done());
-		return m3;
-	}
-
-	public ISet getMacroExpansionsFromTranslationUnit(IASTTranslationUnit tu) {
-		ISetWriter macros = vf.setWriter();
-		Stream.of(tu.getMacroExpansions()).forEach(it -> {
-			ISourceLocation decl;
-			try {
-				decl = br.resolveBinding(it.getMacroReference().resolveBinding());
-			} catch (URISyntaxException e) {
-				decl = vf.sourceLocation(URIUtil.rootScheme("unknown"));
-			}
-			macros.insert(vf.tuple(getSourceLocation(it), decl));
-		});
-		return macros.done();
-	}
-
-	private void addDeclaredType(ISourceLocation decl, IConstructor typ) {
-		if (toM3)
-			declaredType.insert(vf.tuple(decl, typ));
-	}
-
-	public ISet parseForMacros(ISourceLocation file, IList includePath, IMap additionalMacros, IEvaluatorContext ctx) {
-		setIEvaluatorContext(ctx);
-		CDTParser parser = new CDTParser(vf.listWriter().done(), includePath, additionalMacros, true, ctx);
-		IASTTranslationUnit tu = parser.parseFile(file);
-		return getMacroExpansionsFromTranslationUnit(tu);
-	}
-
-	public IValue parseString(IString code, IEvaluatorContext ctx) throws CoreException {
-		return parseString(code, null, ctx);
-	}
-
-	public IValue parseString(IString code, ISourceLocation loc, IEvaluatorContext ctx) throws CoreException {
-		setIEvaluatorContext(ctx);
-		stdLib = vf.listWriter().done();
-		FileContent fc = FileContent.create(loc == null ? "" : loc.toString(), code.getValue().toCharArray());
-		IScannerInfo si = new ScannerInfo();
-		IncludeFileContentProvider ifcp = IncludeFileContentProvider.getEmptyFilesProvider();
-		int options = ILanguage.OPTION_PARSE_INACTIVE_CODE;
-		IParserLogService log = new DefaultLogService();
-		IASTTranslationUnit tu = GPPLanguage.getDefault().getASTTranslationUnit(fc, si, ifcp, null, options, log);
-		return convertCdtToRascal(tu, false);
-	}
-
-	public IValue convertCdtToRascal(IASTTranslationUnit translationUnit, boolean toM3) {
-		this.toM3 = toM3;
-		translationUnit.accept(this);
-		if (stack.size() == 1)
-			return stack.pop();
-		if (stack.size() == 0)
-			throw new RuntimeException("Stack empty after converting, error");
-		IConstructor ast = stack.pop();
-		err("Superfluous nodes on the stack after converting:");
-		stack.iterator().forEachRemaining(it -> err(it.toString()));
-		return ast;
-	}
-
-	public void setIEvaluatorContext(IEvaluatorContext ctx) {
-		this.ctx = ctx;
-		br.setIEvaluatorContext(ctx);
-		tr.setIEvaluatorContext(ctx);
-	}
-
-	private int prefix = 0;
-
-	private String spaces() {
-		return StringUtils.repeat(" ", prefix);
-	}
-
-	private void out(String msg) {
-		ctx.getOutPrinter().println(spaces() + msg.replace("\n", "\n" + spaces()));
-	}
-
-	private void err(String msg) {
-		ctx.getErrorPrinter().println(spaces() + msg.replace("\n", "\n" + spaces()));
-	}
-
-	public ISourceLocation getSourceLocation(IASTNode node) {
-		IASTFileLocation astFileLocation = node.getFileLocation();
-
-		if (astFileLocation != null) {
-			String fileName = astFileLocation.getFileName();
-			fileName = fileName.replace('\\', '/');
-			try {
-				return vf.sourceLocation(
-						(ISourceLocation) new StandardTextReader().read(vf, new StringReader(fileName)),
-						astFileLocation.getNodeOffset(), astFileLocation.getNodeLength());
-			} catch (FactParseError | FactTypeUseException | IOException e) {
-			}
-			if (!fileName.startsWith("/")) {
-				fileName = "/" + fileName;
-			}
-			try {
-				return vf.sourceLocation(
-						(ISourceLocation) new StandardTextReader().read(vf, new StringReader(fileName)),
-						astFileLocation.getNodeOffset(), astFileLocation.getNodeLength());
-			} catch (FactParseError | FactTypeUseException | IOException e) {
-			}
-			return vf.sourceLocation(vf.sourceLocation(fileName), astFileLocation.getNodeOffset(),
-					astFileLocation.getNodeLength());
-		}
-		return vf.sourceLocation(URIUtil.assumeCorrect("unknown:///", "", ""));
-	}
-
-	public ISourceLocation getTokenSourceLocation(IASTNode node, String literal) {
-		ISourceLocation loc = getSourceLocation(node);
-		try {
-			IToken tokens = node.getSyntax();
-			while (tokens != null) {
-				if (literal.equals(tokens.getImage())) {
-					return vf.sourceLocation(loc, loc.getOffset() + tokens.getOffset(), literal.length());
-				}
-				tokens = tokens.getNext();
-			}
-		} catch (ExpansionOverlapsBoundaryException e) {
-			// Fall back to node's source location. Possibly find string in node's image
-		}
-		return loc;
-	}
-
-	public boolean isMacroExpansion(IASTNode node) {
-		IASTNodeLocation[] nodeLocations = node.getNodeLocations();
-		return nodeLocations.length > 1
-				|| nodeLocations.length == 1 && nodeLocations[0] instanceof IASTMacroExpansionLocation;
-	}
-
-	IList getAttributes(IASTAttributeOwner node) {
-		IListWriter attributeSpecifiers = vf.listWriter();
-		Stream.of(node.getAttributeSpecifiers()).forEach(it -> {
-			visit((IASTAttributeSpecifier) it);
-			attributeSpecifiers.append(stack.pop());
-		});
-		return attributeSpecifiers.done();
-	}
-
-	IList getModifiers(IASTNode node) {
-		boolean isMacroExpansion = isMacroExpansion(node);
-		IListWriter modifiers = vf.listWriter();
-
-		if (node instanceof ICPPASTDeclSpecifier) {
-			if (((ICPPASTDeclSpecifier) node).isFriend())
-				modifiers.append(builder.Modifier_friend(getTokenSourceLocation(node, "friend"), isMacroExpansion));
-			if (((ICPPASTDeclSpecifier) node).isVirtual())
-				modifiers.append(builder.Modifier_virtual(getTokenSourceLocation(node, "virtual"), isMacroExpansion));
-			if (((ICPPASTDeclSpecifier) node).isExplicit())
-				modifiers.append(builder.Modifier_explicit(getTokenSourceLocation(node, "explicit"), isMacroExpansion));
-			if (((ICPPASTDeclSpecifier) node).isConstexpr())
-				modifiers.append(
-						builder.Modifier_constexpr(getTokenSourceLocation(node, "constexpr"), isMacroExpansion));
-			if (((ICPPASTDeclSpecifier) node).isThreadLocal())
-				modifiers.append(
-						builder.Modifier_threadLocal(getTokenSourceLocation(node, "thread_local"), isMacroExpansion));
-		}
-
-		if (node instanceof ICPPASTFunctionDeclarator) {
-			if (((ICPPASTFunctionDeclarator) node).isMutable())
-				modifiers.append(builder.Modifier_mutable(getTokenSourceLocation(node, "mutable"), isMacroExpansion));
-			if (((ICPPASTFunctionDeclarator) node).isPureVirtual())
-				modifiers.append(
-						builder.Modifier_pureVirtual(getTokenSourceLocation(node, "virtual"), isMacroExpansion));// check
-		}
-
-		if (node instanceof IASTDeclSpecifier) {
-			switch (((IASTDeclSpecifier) node).getStorageClass()) {
-			case IASTDeclSpecifier.sc_typedef:
-				modifiers.append(builder.Modifier_typedef(getTokenSourceLocation(node, "typedef"), isMacroExpansion));
-				break;
-			case IASTDeclSpecifier.sc_extern:
-				modifiers.append(builder.Modifier_extern(getTokenSourceLocation(node, "extern"), isMacroExpansion));
-				break;
-			case IASTDeclSpecifier.sc_static:
-				modifiers.append(builder.Modifier_static(getTokenSourceLocation(node, "static"), isMacroExpansion));
-				break;
-			case IASTDeclSpecifier.sc_auto:
-				modifiers.append(builder.Modifier_modAuto(getTokenSourceLocation(node, "auto"), isMacroExpansion));
-				break;
-			case IASTDeclSpecifier.sc_register:
-				modifiers.append(builder.Modifier_register(getTokenSourceLocation(node, "register"), isMacroExpansion));
-				break;
-			case IASTDeclSpecifier.sc_mutable:
-				modifiers.append(builder.Modifier_mutable(getTokenSourceLocation(node, "mutable"), isMacroExpansion));
-				break;
-			}
-		}
-
-		if (node instanceof IASTSimpleDeclSpecifier) {
-			if (((IASTSimpleDeclSpecifier) node).isSigned())
-				modifiers.append(builder.Modifier_signed(getTokenSourceLocation(node, "signed"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isUnsigned())
-				modifiers.append(builder.Modifier_unsigned(getTokenSourceLocation(node, "unsigned"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isShort())
-				modifiers.append(builder.Modifier_short(getTokenSourceLocation(node, "short"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isLong())
-				modifiers.append(builder.Modifier_long(getTokenSourceLocation(node, "long"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isLongLong())
-				modifiers
-						.append(builder.Modifier_longlong(getTokenSourceLocation(node, "long long"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isComplex())
-				modifiers.append(builder.Modifier_complex(getTokenSourceLocation(node, "_Complex"), isMacroExpansion));
-			if (((IASTSimpleDeclSpecifier) node).isImaginary())
-				modifiers.append(
-						builder.Modifier_imaginary(getTokenSourceLocation(node, "_Imaginary"), isMacroExpansion));
-		}
-
-		if (node instanceof ICASTArrayModifier) {
-			if (((ICASTArrayModifier) node).isConst())
-				modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
-			if (((ICASTArrayModifier) node).isVolatile())
-				modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
-			if (((ICASTArrayModifier) node).isRestrict())
-				modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
-		} else if (node instanceof ICPPASTFunctionDeclarator) {
-			if (((ICPPASTFunctionDeclarator) node).isConst())
-				modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
-			if (((ICPPASTFunctionDeclarator) node).isVolatile())
-				modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
-		} else if (node instanceof IASTDeclSpecifier) {
-			if (((IASTDeclSpecifier) node).isConst())
-				modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
-			if (((IASTDeclSpecifier) node).isVolatile())
-				modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
-			if (((IASTDeclSpecifier) node).isRestrict())
-				modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
-			if (((IASTDeclSpecifier) node).isInline())
-				modifiers.append(builder.Modifier_inline(getTokenSourceLocation(node, "inline"), isMacroExpansion));
-		} else if (node instanceof IASTPointer) {
-			if (((IASTPointer) node).isConst())
-				modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
-			if (((IASTPointer) node).isVolatile())
-				modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
-			if (((IASTPointer) node).isRestrict())
-				modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
-		} else if (node instanceof ICPPASTNamespaceDefinition) {
-			if (((ICPPASTNamespaceDefinition) node).isInline())
-				modifiers.append(builder.Modifier_inline(getTokenSourceLocation(node, "inline"), isMacroExpansion));
-		}
-
-		if (node instanceof ICPPASTNamedTypeSpecifier) {
-			if (((ICPPASTNamedTypeSpecifier) node).isTypename())
-				modifiers.append(builder.Modifier_typename(getTokenSourceLocation(node, "typename"), isMacroExpansion));
-		} else if (node instanceof ICPPASTUsingDeclaration)
-			if (((ICPPASTUsingDeclaration) node).isTypename())
-				modifiers.append(builder.Modifier_typename(getTokenSourceLocation(node, "typename"), isMacroExpansion));
-
-		return modifiers.done().stream()
-				.sorted((v1, v2) -> ((ISourceLocation) v1.asWithKeywordParameters().getParameter("src")).getOffset()
-						- ((ISourceLocation) v2.asWithKeywordParameters().getParameter("src")).getOffset())
-				.collect(vf.listWriter());
-	}
-
-	@Override
-	public int visit(IASTTranslationUnit tu) {
-		ISourceLocation loc = getSourceLocation(tu);
-		boolean isMacroExpansion = isMacroExpansion(tu);
-		IListWriter declarations = vf.listWriter();
-		declLoop: for (IASTDeclaration declaration : tu.getDeclarations()) {
-			if (ctx.isInterrupted()) {
-				declarations.append(builder.Declaration_problemDeclaration(
-						vf.sourceLocation(URIUtil.assumeCorrect("interrupted:///")), isMacroExpansion));
-				break;
-			}
-			ISourceLocation declLoc = getSourceLocation(declaration);
-			if (!includeStdLib) {
-				for (IValue it : stdLib) {
-					ISourceLocation l = (ISourceLocation) it;
-					if (l.getScheme().equals(declLoc.getScheme()) && declLoc.getPath().startsWith(l.getPath())) {
-						continue declLoop;
-					}
-				}
-			}
-			declaration.accept(this);
-			declarations.append(stack.pop());
-		}
-
-		IConstructor translationUnit = builder.Declaration_translationUnit(declarations.done(), loc, isMacroExpansion);
-		stack.push(translationUnit);
-		return PROCESS_ABORT;
-	}
-
-	// Names
-
-	@Override
-	public int visit(IASTName name) {
-		if (name instanceof IASTImplicitName)
-			visit((IASTImplicitName) name);
-		else if (name instanceof ICPPASTName)
-			visit((ICPPASTName) name);
-		else {
-			err("No sub-interfaced IASTName? " + name.getClass().getName() + ": " + name.getRawSignature());
-			throw new RuntimeException("NYI at " + getSourceLocation(name));
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTImplicitName name) {
-		err("IASTImplicitName " + name.getRawSignature());
-		boolean alternate = name.isAlternate();
-		boolean operator = name.isOperator();
-		IASTName _lastName = name.getLastName();
-		throw new RuntimeException("NYI at " + getSourceLocation(name));
-	}
-
-	public int visit(ICPPASTName name) {
-		ISourceLocation loc = getSourceLocation(name);
-		boolean isMacroExpansion = isMacroExpansion(name);
-		if (name instanceof ICPPASTConversionName)
-			visit((ICPPASTConversionName) name);
-		else if (name instanceof ICPPASTOperatorName)
-			visit((ICPPASTOperatorName) name);
-		else if (name instanceof ICPPASTQualifiedName)
-			visit((ICPPASTQualifiedName) name);
-		else if (name instanceof ICPPASTTemplateId)
-			visit((ICPPASTTemplateId) name);
-		else {
-			stack.push(builder.Name_name(new String(name.toCharArray()), loc, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTConversionName name) {
-		ISourceLocation loc = getSourceLocation(name);
-		boolean isMacroExpansion = isMacroExpansion(name);
-		IConstructor typ = tr.resolveType(name);
-		name.getTypeId().accept(this);
-		stack.push(builder.Name_conversionName(name.toString(), stack.pop(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTOperatorName name) {
-		ISourceLocation loc = getSourceLocation(name);
-		boolean isMacroExpansion = isMacroExpansion(name);
-		stack.push(builder.Name_operatorName(name.toString(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTQualifiedName name) {
-		ISourceLocation loc = getSourceLocation(name);
-		boolean isMacroExpansion = isMacroExpansion(name);
-		ISourceLocation decl = br.resolveBinding(name);
-
-		IListWriter qualifier = vf.listWriter();
-		Stream.of(name.getQualifier()).forEach(it -> {
-			it.accept(this);
-			qualifier.append(stack.pop());
-		});
-
-		name.getLastName().accept(this);
-		IConstructor lastName = stack.pop();
-		// TODO: check fullyQualified
-		if (name.isFullyQualified())
-			;
-		// err("WARNING: ICPPASTQualifiedName has fullyQualified=true");
-		stack.push(builder.Name_qualifiedName(qualifier.done(), lastName, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTemplateId name) {
-		ISourceLocation loc = getSourceLocation(name);
-		boolean isMacroExpansion = isMacroExpansion(name);
-		ISourceLocation decl = br.resolveBinding(name);
-
-		name.getTemplateName().accept(this);
-		IConstructor templateName = stack.pop();
-		IListWriter templateArguments = vf.listWriter();
-		Stream.of(name.getTemplateArguments()).forEach(it -> {
-			it.accept(this);
-			templateArguments.append(stack.pop());
-		});
-		stack.push(builder.Name_templateId(templateName, templateArguments.done(), loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	// Declarations
-
-	@Override
-	public int visit(IASTDeclaration declaration) {
-		if (declaration instanceof IASTASMDeclaration)
-			visit((IASTASMDeclaration) declaration);
-		else if (declaration instanceof IASTFunctionDefinition)
-			visit((IASTFunctionDefinition) declaration);
-		else if (declaration instanceof IASTSimpleDeclaration)
-			visit((IASTSimpleDeclaration) declaration);
-		else if (declaration instanceof ICPPASTAliasDeclaration)
-			visit((ICPPASTAliasDeclaration) declaration);
-		else if (declaration instanceof ICPPASTExplicitTemplateInstantiation)
-			visit((ICPPASTExplicitTemplateInstantiation) declaration);
-		else if (declaration instanceof ICPPASTLinkageSpecification)
-			visit((ICPPASTLinkageSpecification) declaration);
-		else if (declaration instanceof ICPPASTNamespaceAlias)
-			visit((ICPPASTNamespaceAlias) declaration);
-		// In ASTVisitor interface, not needed?
-		// else if (declaration instanceof ICPPASTNamespaceDefinition)
-		// visit((ICPPASTNamespaceDefinition) declaration);
-		else if (declaration instanceof ICPPASTStaticAssertDeclaration)
-			visit((ICPPASTStaticAssertDeclaration) declaration);
-		else if (declaration instanceof ICPPASTTemplateSpecialization)
-			visit((ICPPASTTemplateSpecialization) declaration);
-		else if (declaration instanceof ICPPASTTemplateDeclaration)
-			visit((ICPPASTTemplateDeclaration) declaration);
-		else if (declaration instanceof ICPPASTUsingDeclaration)
-			visit((ICPPASTUsingDeclaration) declaration);
-		else if (declaration instanceof ICPPASTUsingDirective)
-			visit((ICPPASTUsingDirective) declaration);
-		else if (declaration instanceof ICPPASTVisibilityLabel)
-			visit((ICPPASTVisibilityLabel) declaration);
-		else if (declaration instanceof IASTProblemDeclaration)
-			// should not happen
-			visit((IASTProblemDeclaration) declaration);
-		else {
-			throw new RuntimeException("Declaration: encountered non-implemented subtype "
-					+ declaration.getClass().getName() + " at " + getSourceLocation(declaration));
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTAliasDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		ISourceLocation decl = br.resolveBinding(declaration);
-		IList attributes = getAttributes(declaration);
-
-		declaration.getAlias().accept(this);
-		IConstructor alias = stack.pop();
-		declaration.getMappingTypeId().accept(this);
-		IConstructor mappingTypeId = stack.pop();
-		stack.push(builder.Declaration_alias(alias, mappingTypeId, attributes, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTExplicitTemplateInstantiation declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		declaration.getDeclaration().accept(this);
-		switch (declaration.getModifier()) {
-		case 0:
-			stack.push(builder.Declaration_explicitTemplateInstantiation(stack.pop(), loc, isMacroExpansion));
-			break;
-		case ICPPASTExplicitTemplateInstantiation.STATIC:
-			stack.push(builder.Declaration_explicitTemplateInstantiation(
-					builder.Modifier_static(getTokenSourceLocation(declaration, "static"), isMacroExpansion),
-					stack.pop(), loc, isMacroExpansion));
-			break;
-		case ICPPASTExplicitTemplateInstantiation.INLINE:
-			stack.push(builder.Declaration_explicitTemplateInstantiation(
-					builder.Modifier_inline(getTokenSourceLocation(declaration, "inline"), isMacroExpansion),
-					stack.pop(), loc, isMacroExpansion));
-			break;
-		case ICPPASTExplicitTemplateInstantiation.EXTERN:
-			stack.push(builder.Declaration_explicitTemplateInstantiation(
-					builder.Modifier_extern(getTokenSourceLocation(declaration, "extern"), isMacroExpansion),
-					stack.pop(), loc, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("ICPPASTExplicitTemplateInstantiation encountered unknown modifier "
-					+ declaration.getModifier() + " at " + getSourceLocation(declaration));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTLinkageSpecification declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-
-		IListWriter declarations = vf.listWriter();
-		Stream.of(declaration.getDeclarations()).forEach(it -> {
-			it.accept(this);
-			declarations.append(stack.pop());
-		});
-		stack.push(builder.Declaration_linkageSpecification(declaration.getLiteral(), declarations.done(), loc,
-				isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTNamespaceAlias declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		ISourceLocation decl = br.resolveBinding(declaration);
-
-		declaration.getAlias().accept(this);
-		IConstructor alias = stack.pop();
-		declaration.getMappingName().accept(this);
-		IConstructor mappingName = stack.pop();
-		stack.push(builder.Declaration_namespaceAlias(alias, mappingName, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTStaticAssertDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		declaration.getCondition().accept(this);
-		IConstructor condition = stack.pop();
-		declaration.getMessage().accept(this);
-		stack.push(builder.Declaration_staticAssert(condition, stack.pop(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTemplateDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		IConstructor typ = tr.resolveType(declaration);
-		// The "export" keyword has been removed from the C++ standard
-		IListWriter templateParameters = vf.listWriter();
-		Stream.of(declaration.getTemplateParameters()).forEach(it -> {
-			it.accept(this);
-			templateParameters.append(stack.pop());
-		});
-		declaration.getDeclaration().accept(this);
-		stack.push(builder.Declaration_template(templateParameters.done(), stack.pop(), typ, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTemplateSpecialization declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		declaration.getDeclaration().accept(this);
-		stack.push(builder.Declaration_explicitTemplateSpecialization(stack.pop(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTUsingDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		ISourceLocation decl = br.resolveBinding(declaration);
-		IList attributes = getAttributes(declaration);
-		IList modifiers = getModifiers(declaration);
-		declaration.getName().accept(this);
-		stack.push(
-				builder.Declaration_usingDeclaration(modifiers, stack.pop(), attributes, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTUsingDirective declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		ISourceLocation decl = br.resolveBinding(declaration);
-		IList attributes = getAttributes(declaration);
-		IASTName qualifiedName = declaration.getQualifiedName();
-		qualifiedName.accept(this);
-		stack.push(builder.Declaration_usingDirective(stack.pop(), attributes, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTVisibilityLabel declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		switch (declaration.getVisibility()) {
-		case ICPPASTVisibilityLabel.v_public:
-			stack.push(builder.Declaration_visibilityLabel(
-					builder.Modifier_public(getTokenSourceLocation(declaration, "public"), isMacroExpansion), loc,
-					isMacroExpansion));
-			break;
-		case ICPPASTVisibilityLabel.v_protected:
-			stack.push(builder.Declaration_visibilityLabel(
-					builder.Modifier_protected(getTokenSourceLocation(declaration, "protected"), isMacroExpansion), loc,
-					isMacroExpansion));
-			break;
-		case ICPPASTVisibilityLabel.v_private:
-			stack.push(builder.Declaration_visibilityLabel(
-					builder.Modifier_private(getTokenSourceLocation(declaration, "private"), isMacroExpansion), loc,
-					isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("Unknown CPPVisibilityLabel code " + declaration.getVisibility() + " at "
-					+ getSourceLocation(declaration) + ". Exiting");
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTASMDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		stack.push(builder.Declaration_asmDeclaration(declaration.getAssembly(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTFunctionDefinition definition) {
-		ISourceLocation loc = getSourceLocation(definition);
-		boolean isMacroExpansion = isMacroExpansion(definition);
-		if (definition instanceof ICPPASTFunctionDefinition) {
-			IList attributes = getAttributes((ICPPASTFunctionDefinition) definition);
-			boolean isDefaulted = ((ICPPASTFunctionDefinition) definition).isDefaulted();
-			boolean isDeleted = ((ICPPASTFunctionDefinition) definition).isDeleted();
-
-			definition.getDeclSpecifier().accept(this);
-			IConstructor declSpecifier = stack.pop();
-			definition.getDeclarator().accept(this);
-			IConstructor declarator = stack.pop();
-
-			IListWriter memberInitializers = vf.listWriter();
-			Stream.of(((ICPPASTFunctionDefinition) definition).getMemberInitializers()).forEach(it -> {
-				it.accept(this);
-				memberInitializers.append(stack.pop());
-			});
-
-			if (isDefaulted && isDeleted)
-				err("WARNING: IASTFunctionDefinition both deleted and defaulted");
-			if ((isDefaulted || isDeleted) && definition instanceof ICPPASTFunctionWithTryBlock)
-				throw new RuntimeException("IASTFunctionDefinition defaulted/deleted and with try? at " + loc);
-			if (isDefaulted)
-				stack.push(builder.Declaration_defaultedFunctionDefinition(declSpecifier, memberInitializers.done(),
-						declarator, attributes, loc, isMacroExpansion));
-			else if (isDeleted)
-				stack.push(builder.Declaration_deletedFunctionDefinition(declSpecifier, memberInitializers.done(),
-						declarator, attributes, loc, isMacroExpansion));
-			else if (definition instanceof ICPPASTFunctionWithTryBlock) {
-				IListWriter catchHandlers = vf.listWriter();
-				Stream.of(((ICPPASTFunctionWithTryBlock) definition).getCatchHandlers()).forEach(it -> {
-					it.accept(this);
-					catchHandlers.append(stack.pop());
-				});
-				definition.getBody().accept(this);
-				stack.push(builder.Declaration_functionWithTryBlockDefinition(declSpecifier, declarator,
-						memberInitializers.done(), stack.pop(), catchHandlers.done(), attributes, loc,
-						isMacroExpansion));
-			} else {
-				definition.getBody().accept(this);
-				stack.push(builder.Declaration_functionDefinition(declSpecifier, declarator, memberInitializers.done(),
-						stack.pop(), attributes, loc, isMacroExpansion));
-			}
-			addDeclaredType(br.resolveBinding(definition.getDeclarator()), tr.resolveType(definition.getDeclarator()));
-		} else { // C Function definition
-			throw new RuntimeException("Encountered C function definition at " + loc + ", NYI");
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTParameterDeclaration parameterDeclaration) {
-		ISourceLocation loc = getSourceLocation(parameterDeclaration);
-		boolean isMacroExpansion = isMacroExpansion(parameterDeclaration);
-		if (parameterDeclaration instanceof ICPPASTParameterDeclaration) {
-			// TODO: add isParameterPack()
-			ICPPASTParameterDeclaration declaration = (ICPPASTParameterDeclaration) parameterDeclaration;
-
-			declaration.getDeclSpecifier().accept(this);
-			IConstructor declSpecifier = stack.pop();
-			if (declaration.getDeclarator() == null)
-				stack.push(builder.Declaration_parameter(declSpecifier, loc, isMacroExpansion));
-			else {
-				declaration.getDeclarator().accept(this);
-				stack.push(builder.Declaration_parameter(declSpecifier, stack.pop(), loc, isMacroExpansion));
-			}
-		} else {
-			throw new RuntimeException("NYI: C ParameterDeclaration at " + loc);
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTProblemDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		IASTProblem problem = declaration.getProblem();
-		String raw = declaration.getRawSignature();
-		if (doProblemLogging) {
-			if (!(raw.contains("$fail$") || raw.contains("�") || raw.contains("__int64(24)")
-					|| raw.contains("CString default"))) {
-				err("ProblemDeclaration: ");
-				prefix += 4;
-				err(Integer.toHexString(problem.getID()) + ": " + problem.getMessageWithLocation() + ", " + loc);
-				err(raw);
-				prefix -= 4;
-			}
-		}
-		stack.push(builder.Declaration_problemDeclaration(loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTSimpleDeclaration declaration) {
-		ISourceLocation loc = getSourceLocation(declaration);
-		boolean isMacroExpansion = isMacroExpansion(declaration);
-		IList attributes = getAttributes(declaration);
-
-		declaration.getDeclSpecifier().accept(this);
-		IConstructor declSpecifier = stack.pop();
-
-		IListWriter declarators = vf.listWriter();
-		Stream.of(declaration.getDeclarators()).forEach(it -> {
-			it.accept(this);
-			declarators.append(stack.pop());
-			addDeclaredType(br.resolveBinding(it), tr.resolveType(it));
-		});
-		stack.push(builder.Declaration_simpleDeclaration(declSpecifier, declarators.done(), attributes, loc,
-				isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	// Initializers
-
-	@Override
-	public int visit(IASTInitializer initializer) {
-		if (initializer instanceof IASTEqualsInitializer)
-			visit((IASTEqualsInitializer) initializer);
-		else if (initializer instanceof IASTInitializerList)
-			visit((IASTInitializerList) initializer);
-		else if (initializer instanceof ICASTDesignatedInitializer)
-			visit((ICASTDesignatedInitializer) initializer);
-		else if (initializer instanceof ICPPASTConstructorChainInitializer)
-			visit((ICPPASTConstructorChainInitializer) initializer);
-		else if (initializer instanceof ICPPASTConstructorInitializer)
-			visit((ICPPASTConstructorInitializer) initializer);
-		else if (initializer instanceof ICPPASTDesignatedInitializer)
-			visit((ICPPASTDesignatedInitializer) initializer);
-		else {
-			throw new RuntimeException("Initializer: encountered unknown subtype "
-					+ initializer.getClass().getSimpleName() + " at " + getSourceLocation(initializer));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTEqualsInitializer initializer) {
-		ISourceLocation loc = getSourceLocation(initializer);
-		boolean isMacroExpansion = isMacroExpansion(initializer);
-		initializer.getInitializerClause().accept(this);
-		stack.push(builder.Expression_equalsInitializer(stack.pop(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTInitializerList initializer) {
-		// TODO: cpp: check isPackExpansion, maybe getSize
-		ISourceLocation loc = getSourceLocation(initializer);
-		boolean isMacroExpansion = isMacroExpansion(initializer);
-		IListWriter clauses = vf.listWriter();
-		Stream.of(initializer.getClauses()).forEach(it -> {
-			it.accept(this);
-			clauses.append(stack.pop());
-		});
-		stack.push(builder.Expression_initializerList(clauses.done(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICASTDesignatedInitializer initializer) {
-		err("ICASTDesignatedInitializer: " + initializer.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(initializer));
-	}
-
-	public int visit(ICPPASTConstructorChainInitializer initializer) {
-		// TODO: check isPackExpansion
-		ISourceLocation loc = getSourceLocation(initializer);
-		boolean isMacroExpansion = isMacroExpansion(initializer);
-		ISourceLocation decl = br.resolveBinding(initializer);
-
-		initializer.getMemberInitializerId().accept(this);
-		IConstructor memberInitializerId = stack.pop();
-		initializer.getInitializer().accept(this);
-		IConstructor memberInitializer = stack.pop();
-
-		stack.push(builder.Expression_constructorChainInitializer(memberInitializerId, memberInitializer, loc, decl,
-				isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTConstructorInitializer initializer) {
-		ISourceLocation loc = getSourceLocation(initializer);
-		boolean isMacroExpansion = isMacroExpansion(initializer);
-
-		IListWriter arguments = vf.listWriter();
-		Stream.of(initializer.getArguments()).forEach(it -> {
-			it.accept(this);
-			arguments.append(stack.pop());
-		});
-
-		stack.push(builder.Expression_constructorInitializer(arguments.done(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTDesignatedInitializer initializer) {
-		ISourceLocation loc = getSourceLocation(initializer);
-		boolean isMacroExpansion = isMacroExpansion(initializer);
-
-		IListWriter designators = vf.listWriter();
-		Stream.of(initializer.getDesignators()).forEach(it -> {
-			it.accept(this);
-			designators.append(stack.pop());
-		});
-
-		initializer.getOperand().accept(this);
-		stack.push(builder.Expression_designatedInitializer(designators.done(), stack.pop(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	// InitializerClauses
-
-	public int visit(IASTInitializerClause initializerClause) {
-		if (initializerClause instanceof IASTExpression)
-			visit((IASTExpression) initializerClause);
-		else if (initializerClause instanceof IASTInitializerList)
-			visit((IASTInitializerList) initializerClause);
-		else if (initializerClause instanceof ICASTDesignatedInitializer)
-			visit((ICASTDesignatedInitializer) initializerClause);
-		else if (initializerClause instanceof ICPPASTInitializerClause)
-			visit((ICPPASTInitializerClause) initializerClause);
-		else
-			throw new RuntimeException(
-					"Unknown IASTInitializerClause subclass " + initializerClause.getClass().getName() + " at "
-							+ getSourceLocation(initializerClause) + ". Exiting");
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTInitializerClause initializer) {
-		err("ICPPASTInitializerClause: " + initializer.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(initializer));
-	}
-
-	// Declarators
-
-	@Override
-	public int visit(IASTDeclarator declarator) {
-		if (declarator instanceof IASTArrayDeclarator)
-			visit((IASTArrayDeclarator) declarator);
-		else if (declarator instanceof IASTFunctionDeclarator)
-			visit((IASTFunctionDeclarator) declarator);
-		else if (declarator instanceof ICPPASTDeclarator)
-			visit((ICPPASTDeclarator) declarator);
-		else {
-			throw new RuntimeException("Unknown IASTDeclarator subclass " + declarator.getClass().getName() + "at "
-					+ getSourceLocation(declarator));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTArrayDeclarator declarator) {
-		ISourceLocation loc = getSourceLocation(declarator);
-		boolean isMacroExpansion = isMacroExpansion(declarator);
-		ISourceLocation decl = br.resolveBinding(declarator);
-		IList attributes = getAttributes(declarator);
-
-		IListWriter arrayModifiers = vf.listWriter();
-		Stream.of(declarator.getArrayModifiers()).forEach(it -> {
-			it.accept(this);
-			arrayModifiers.append(stack.pop());
-		});
-
-		IListWriter pointerOperators = vf.listWriter();
-		Stream.of(declarator.getPointerOperators()).forEach(it -> {
-			it.accept(this);
-			pointerOperators.append(stack.pop());
-		});
-
-		declarator.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		// TODO: check declaresParameterPack
-		if (declarator instanceof ICPPASTArrayDeclarator
-				&& ((ICPPASTArrayDeclarator) declarator).declaresParameterPack())
-			out("WARNING: IASTArrayDeclarator has declaresParameterPack=true");
-
-		if (declarator.getNestedDeclarator() == null) {
-			if (declarator.getInitializer() == null)
-				stack.push(builder.Declarator_arrayDeclarator(pointerOperators.done(), name, arrayModifiers.done(),
-						attributes, loc, decl, isMacroExpansion));
-			else {
-				declarator.getInitializer().accept(this);
-				stack.push(builder.Declarator_arrayDeclarator(pointerOperators.done(), name, arrayModifiers.done(),
-						stack.pop(), attributes, loc, decl, isMacroExpansion));
-			}
-		} else {
-			declarator.getNestedDeclarator().accept(this);
-			IConstructor nestedDeclarator = stack.pop();
-			if (declarator.getInitializer() == null)
-				stack.push(builder.Declarator_arrayDeclaratorNested(pointerOperators.done(), nestedDeclarator,
-						arrayModifiers.done(), attributes, loc, decl, isMacroExpansion));
-			else {
-				declarator.getInitializer().accept(this);
-				stack.push(builder.Declarator_arrayDeclaratorNested(pointerOperators.done(), nestedDeclarator,
-						arrayModifiers.done(), stack.pop(), attributes, loc, decl, isMacroExpansion));
-			}
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTFieldDeclarator declarator) {
-		err("FieldDeclarator: " + declarator.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declarator));
-	}
-
-	public int visit(IASTFunctionDeclarator declarator) {
-		if (declarator instanceof IASTStandardFunctionDeclarator)
-			visit((IASTStandardFunctionDeclarator) declarator);
-		else if (declarator instanceof ICASTKnRFunctionDeclarator)
-			visit((ICASTKnRFunctionDeclarator) declarator);
-		else
-			throw new RuntimeException("Unknown FunctionDeclarator subtype " + declarator.getClass().getName() + " at "
-					+ getSourceLocation(declarator) + ". Exiting");
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTStandardFunctionDeclarator declarator) {
-		if (declarator instanceof ICPPASTFunctionDeclarator)
-			visit((ICPPASTFunctionDeclarator) declarator);
-		else {
-			throw new RuntimeException("Unknown StandardFunctionDeclarator subtype " + declarator.getClass().getName()
-					+ " at " + getSourceLocation(declarator) + ". Exiting");
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICASTKnRFunctionDeclarator declarator) {
-		err("CKnRFunctionDeclarator: " + declarator.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declarator));
-	}
-
-	public int visit(ICPPASTDeclarator declarator) {
-		if (declarator instanceof ICPPASTArrayDeclarator)
-			visit((ICPPASTArrayDeclarator) declarator);
-		else if (declarator instanceof ICPPASTFieldDeclarator)
-			visit((ICPPASTFieldDeclarator) declarator);
-		else if (declarator instanceof ICPPASTFunctionDeclarator)
-			visit((ICPPASTFunctionDeclarator) declarator);
-		else {
-			ISourceLocation loc = getSourceLocation(declarator);
-			boolean isMacroExpansion = isMacroExpansion(declarator);
-			ISourceLocation decl = br.resolveBinding(declarator);
-			IList attributes = getAttributes(declarator);
-
-			// if (declarator.getNestedDeclarator() != null)
-			// err("WARNING: ICPPASTDeclarator has nestedDeclarator " +
-			// _nestedDeclarator.getRawSignature());
-
-			declarator.getName().accept(this);
-			IConstructor name = stack.pop();
-
-			IListWriter pointerOperators = vf.listWriter();
-			Stream.of(declarator.getPointerOperators()).forEach(it -> {
-				it.accept(this);
-				pointerOperators.append(stack.pop());
-			});
-
-			IASTInitializer initializer = declarator.getInitializer();
-			if (initializer == null) {
-				stack.push(builder.Declarator_declarator(pointerOperators.done(), name, attributes, loc, decl,
-						isMacroExpansion));
-			} else {
-				initializer.accept(this);
-				stack.push(builder.Declarator_declarator(pointerOperators.done(), name, stack.pop(), attributes, loc,
-						decl, isMacroExpansion));
-			}
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTArrayDeclarator declarator) {
-		visit((IASTArrayDeclarator) declarator);
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTFieldDeclarator declarator) {
-		ISourceLocation loc = getSourceLocation(declarator);
-		boolean isMacroExpansion = isMacroExpansion(declarator);
-		ISourceLocation decl = br.resolveBinding(declarator);
-		IList attributes = getAttributes(declarator);
-
-		IListWriter pointerOperators = vf.listWriter();
-		Stream.of(declarator.getPointerOperators()).forEach(it -> {
-			it.accept(this);
-			pointerOperators.append(stack.pop());
-		});
-
-		declarator.getBitFieldSize().accept(this);
-		IConstructor bitFieldSize = stack.pop();
-		declarator.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		IASTDeclarator nestedDeclarator = declarator.getNestedDeclarator();
-		if (nestedDeclarator != null)
-			err("WARNING: ICPPASTDeclarator has nestedDeclarator " + nestedDeclarator.getRawSignature());
-
-		IASTInitializer initializer = declarator.getInitializer();
-		if (initializer == null) {
-			stack.push(builder.Declarator_fieldDeclarator(pointerOperators.done(), name, bitFieldSize, attributes, loc,
-					decl, isMacroExpansion));
-		} else {
-			initializer.accept(this);
-			stack.push(builder.Declarator_fieldDeclarator(pointerOperators.done(), name, bitFieldSize, stack.pop(),
-					attributes, loc, decl, isMacroExpansion));
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTFunctionDeclarator declarator) {
-		// TODO: check refQualifier and declaresParameterPack
-		ISourceLocation loc = getSourceLocation(declarator);
-		boolean isMacroExpansion = isMacroExpansion(declarator);
-		ISourceLocation decl = br.resolveBinding(declarator);
-//		IConstructor typ = tr.resolveType(declarator);
-		IList attributes = getAttributes(declarator);
-		IList modifiers = getModifiers(declarator);
-
-		IASTDeclarator _nestedDeclarator = declarator.getNestedDeclarator();
-		IASTInitializer _initializer = declarator.getInitializer();
-		IASTTypeId _trailingReturnType = declarator.getTrailingReturnType();
-		IASTTypeId[] _exceptionSpecification = declarator.getExceptionSpecification();
-		ICPPASTExpression _noexceptExpression = declarator.getNoexceptExpression();
-
-		// TODO: fix when name == null
-		IConstructor name = builder.Name_name("", vf.sourceLocation(loc, loc.getOffset(), 0), isMacroExpansion);
-		IASTName _name = declarator.getName();
-		if (_name != null) {
-			_name.accept(this);
-			name = stack.pop();
-		}
-
-		IListWriter parameters = vf.listWriter();
-		Stream.of(declarator.getParameters()).forEach(it -> {
-			it.accept(this);
-			parameters.append(stack.pop());
-		});
-		if (declarator.takesVarArgs())
-			parameters.append(builder.Declaration_varArgs(getTokenSourceLocation(declarator, "..."), isMacroExpansion));
-
-		IListWriter virtSpecifiers = vf.listWriter();
-		Stream.of(declarator.getVirtSpecifiers()).forEach(it -> {
-			it.accept(this);
-			virtSpecifiers.append(stack.pop());
-		});
-
-		IListWriter pointerOperators = vf.listWriter();
-		Stream.of(declarator.getPointerOperators()).forEach(it -> {
-			it.accept(this);
-			pointerOperators.append(stack.pop());
-		});
-
-		if (_nestedDeclarator != null) {
-			if (_trailingReturnType != null)
-				throw new RuntimeException("FunctionDeclarator: Trailing return type and nested declarator? at " + loc);
-			_nestedDeclarator.accept(this);
-			IConstructor nestedDeclarator = stack.pop();
-			if (_initializer == null)
-				stack.push(builder.Declarator_functionDeclaratorNested(pointerOperators.done(), modifiers,
-						nestedDeclarator, parameters.done(), virtSpecifiers.done(), attributes, loc, decl,
-						isMacroExpansion));
-			else {
-				_initializer.accept(this);
-				stack.push(builder.Declarator_functionDeclaratorNested(pointerOperators.done(), modifiers,
-						nestedDeclarator, parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl,
-						isMacroExpansion));
-			}
-			// if
-			// (!(_exceptionSpecification.equals(ICPPASTFunctionDeclarator.NO_EXCEPTION_SPECIFICATION)))
-			// err("WARNING: ICPPASTFunctionDeclaration had nestedDeclarator and
-			// also exceptionSpecification");
-		} else if (_exceptionSpecification.equals(ICPPASTFunctionDeclarator.NO_EXCEPTION_SPECIFICATION)) {
-			if (_trailingReturnType == null)
-				stack.push(builder.Declarator_functionDeclarator(pointerOperators.done(), modifiers, name,
-						parameters.done(), virtSpecifiers.done(), attributes, loc, decl, isMacroExpansion));
-			else {
-				_trailingReturnType.accept(this);
-				stack.push(builder.Declarator_functionDeclarator(pointerOperators.done(), modifiers, name,
-						parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl,
-						isMacroExpansion));
-			}
-		} else if (_exceptionSpecification.equals(IASTTypeId.EMPTY_TYPEID_ARRAY)) {
-			if (_trailingReturnType != null)
-				throw new RuntimeException(
-						"FunctionDeclarator: Trailing return type and exception specification? at " + loc);
-			stack.push(builder.Declarator_functionDeclaratorWithES(pointerOperators.done(), modifiers, name,
-					parameters.done(), virtSpecifiers.done(), attributes, loc, decl, isMacroExpansion));
-		} else if (_noexceptExpression != null) {
-			if (_trailingReturnType != null)
-				throw new RuntimeException(
-						"FunctionDeclarator: Trailing return type and noexceptExpression? at " + loc);
-			if (_initializer != null)
-				throw new RuntimeException("FunctionDeclarator: Initializer and noexceptExpression? at " + loc);
-			_noexceptExpression.accept(this);
-			stack.push(builder.Declarator_functionDeclaratorNoexcept(pointerOperators.done(), modifiers, name,
-					parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl, isMacroExpansion));
-		} else {
-			if (_trailingReturnType != null)
-				throw new RuntimeException(
-						"FunctionDeclarator: Trailing return type and exception specification? at " + loc);
-			IListWriter exceptionSpecification = vf.listWriter();
-			Stream.of(_exceptionSpecification).forEach(it -> {
-				it.accept(this);
-				exceptionSpecification.append(stack.pop());
-			});
-			stack.push(builder.Declarator_functionDeclaratorWithES(pointerOperators.done(), modifiers, name,
-					parameters.done(), virtSpecifiers.done(), exceptionSpecification.done(), attributes, loc, decl,
-					isMacroExpansion));
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	// DeclSpecifiers
-
-	@Override
-	public int visit(IASTDeclSpecifier declSpec) {
-		if (declSpec instanceof IASTCompositeTypeSpecifier)
-			visit((IASTCompositeTypeSpecifier) declSpec);
-		else if (declSpec instanceof IASTElaboratedTypeSpecifier)
-			visit((IASTElaboratedTypeSpecifier) declSpec);
-		else if (declSpec instanceof IASTEnumerationSpecifier)
-			visit((IASTEnumerationSpecifier) declSpec);
-		else if (declSpec instanceof IASTNamedTypeSpecifier)
-			visit((IASTNamedTypeSpecifier) declSpec);
-		else if (declSpec instanceof IASTSimpleDeclSpecifier)
-			visit((IASTSimpleDeclSpecifier) declSpec);
-		else if (declSpec instanceof ICASTDeclSpecifier)
-			visit((ICASTDeclSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTDeclSpecifier)
-			visit((ICPPASTDeclSpecifier) declSpec);
-		else
-			throw new RuntimeException("Unknown sub-class encountered: " + declSpec.getClass().getName() + " at "
-					+ getSourceLocation(declSpec) + ". Exiting");
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTCompositeTypeSpecifier declSpec) {
-		if (declSpec instanceof ICASTCompositeTypeSpecifier)
-			visit((ICASTCompositeTypeSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTCompositeTypeSpecifier)
-			visit((ICPPASTCompositeTypeSpecifier) declSpec);
-		else
-			throw new RuntimeException("Unknown IASTCompositeTypeSpecifier subinterface "
-					+ declSpec.getClass().getName() + " at " + getSourceLocation(declSpec));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICASTCompositeTypeSpecifier declSpec) {
-		throw new RuntimeException("C-style CompositeTypeSpecifier encountered at " + getSourceLocation(declSpec));
-	}
-
-	public int visit(ICPPASTCompositeTypeSpecifier declSpec) {
-		ISourceLocation loc = getSourceLocation(declSpec);
-		boolean isMacroExpansion = isMacroExpansion(declSpec);
-		ISourceLocation decl = br.resolveBinding(declSpec);
-		IConstructor typ = tr.resolveType(declSpec);
-		IList attributes = getAttributes(declSpec);
-		IList modifiers = getModifiers(declSpec);
-
-		ICPPASTClassVirtSpecifier virtSpecifier = declSpec.getVirtSpecifier();
-		if (virtSpecifier != null && !(virtSpecifier.getKind().equals(ICPPASTClassVirtSpecifier.SpecifierKind.Final)))
-			throw new RuntimeException(
-					"ICPPASTCompositeTypeSpecifier encountered unknown classVirtSpecifier type at " + loc);
-
-		declSpec.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		IListWriter members = vf.listWriter();
-		Stream.of(declSpec.getMembers()).forEach(it -> {
-			it.accept(this);
-			members.append(stack.pop());
-		});
-
-		IListWriter baseSpecifiers = vf.listWriter();
-		Stream.of(declSpec.getBaseSpecifiers()).forEach(it -> {
-			it.accept(this);
-			baseSpecifiers.append(stack.pop());
-		});
-
-		switch (declSpec.getKey()) {
-		case ICPPASTCompositeTypeSpecifier.k_struct:
-			if (virtSpecifier == null)
-				stack.push(builder.DeclSpecifier_struct(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			else
-				stack.push(builder.DeclSpecifier_structFinal(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			break;
-		case ICPPASTCompositeTypeSpecifier.k_union:
-			if (virtSpecifier == null)
-				stack.push(builder.DeclSpecifier_union(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			else
-				stack.push(builder.DeclSpecifier_unionFinal(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			break;
-		case ICPPASTCompositeTypeSpecifier.k_class:
-			if (virtSpecifier == null)
-				stack.push(builder.DeclSpecifier_class(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			else
-				stack.push(builder.DeclSpecifier_classFinal(modifiers, name, baseSpecifiers.done(), members.done(),
-						attributes, loc, decl, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Unknown IASTCompositeTypeSpecifier code " + declSpec.getKey() + "at" + loc + ". Exiting");
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTElaboratedTypeSpecifier declSpec) {
-		ISourceLocation loc = getSourceLocation(declSpec);
-		if (declSpec instanceof ICPPASTElaboratedTypeSpecifier) {
-			boolean isMacroExpansion = isMacroExpansion(declSpec);
-			ISourceLocation decl = br.resolveBinding(declSpec);
-			IList modifiers = getModifiers(declSpec);
-
-			declSpec.getName().accept(this);
-			switch (declSpec.getKind()) {
-			case ICPPASTElaboratedTypeSpecifier.k_enum:
-				stack.push(builder.DeclSpecifier_etsEnum(modifiers, stack.pop(), loc, decl, isMacroExpansion));
-				break;
-			case ICPPASTElaboratedTypeSpecifier.k_struct:
-				stack.push(builder.DeclSpecifier_etsStruct(modifiers, stack.pop(), loc, decl, isMacroExpansion));
-				break;
-			case ICPPASTElaboratedTypeSpecifier.k_union:
-				stack.push(builder.DeclSpecifier_etsUnion(modifiers, stack.pop(), loc, decl, isMacroExpansion));
-				break;
-			case ICPPASTElaboratedTypeSpecifier.k_class:
-				stack.push(builder.DeclSpecifier_etsClass(modifiers, stack.pop(), loc, decl, isMacroExpansion));
-				break;
-			default:
-				throw new RuntimeException(
-						"IASTElaboratedTypeSpecifier encountered unknown kind " + declSpec.getKind() + " at " + loc);
-			}
-		} else {
-			throw new RuntimeException("Unknown IASTElaboratedTypeSpecifier subclass "
-					+ declSpec.getClass().getSimpleName() + " at " + loc);
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTEnumerationSpecifier declSpec) {
-		if (declSpec instanceof ICPPASTEnumerationSpecifier)
-			visit((ICPPASTEnumerationSpecifier) declSpec);
-		else
-			throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTNamedTypeSpecifier declSpec) {
-		ISourceLocation loc = getSourceLocation(declSpec);
-		boolean isMacroExpansion = isMacroExpansion(declSpec);
-		ISourceLocation decl = br.resolveBinding(declSpec);
-		IList modifiers = getModifiers(declSpec);
-		declSpec.getName().accept(this);
-		stack.push(builder.DeclSpecifier_namedTypeSpecifier(modifiers, stack.pop(), loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTSimpleDeclSpecifier declSpec) {
-		if (declSpec instanceof ICPPASTSimpleDeclSpecifier) {
-			visit((ICPPASTSimpleDeclSpecifier) declSpec);
-			return PROCESS_ABORT;
-		}
-		throw new RuntimeException("NYI: C SimpleDeclSpecifier");
-	}
-
-	public int visit(ICASTDeclSpecifier declSpec) {
-		out("CDeclSpecifier: " + declSpec.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-	}
-
-	public int visit(ICPPASTDeclSpecifier declSpec) {
-		if (declSpec instanceof ICPPASTCompositeTypeSpecifier)
-			visit((ICPPASTCompositeTypeSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTElaboratedTypeSpecifier)
-			visit((ICPPASTElaboratedTypeSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTEnumerationSpecifier)
-			visit((ICPPASTEnumerationSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTNamedTypeSpecifier)
-			visit((ICPPASTNamedTypeSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTSimpleDeclSpecifier)
-			visit((ICPPASTSimpleDeclSpecifier) declSpec);
-		else if (declSpec instanceof ICPPASTTypeTransformationSpecifier)
-			visit((ICPPASTTypeTransformationSpecifier) declSpec);
-		else {
-			throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTElaboratedTypeSpecifier declSpec) {
-		out("CPPElaboratedTypeSpecifier: " + declSpec.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-	}
-
-	public int visit(ICPPASTEnumerationSpecifier declSpec) {
-		ISourceLocation loc = getSourceLocation(declSpec);
-		boolean isMacroExpansion = isMacroExpansion(declSpec);
-		ISourceLocation decl = br.resolveBinding(declSpec);
-		IConstructor typ = tr.resolveType(declSpec);
-		IList attributes = getAttributes(declSpec);
-		IList modifiers = getModifiers(declSpec);
-
-		declSpec.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		IListWriter enumerators = vf.listWriter();
-		Stream.of(declSpec.getEnumerators()).forEach(it -> {
-			it.accept(this);
-			enumerators.append(stack.pop());
-		});
-
-		IASTDeclSpecifier baseType = declSpec.getBaseType();
-		if (baseType == null) {
-			if (declSpec.isScoped()) {
-				if (declSpec.isOpaque())
-					stack.push(builder.DeclSpecifier_enumScopedOpaque(modifiers, name, attributes, loc, decl,
-							isMacroExpansion));
-				else
-					stack.push(builder.DeclSpecifier_enumScoped(modifiers, name, enumerators.done(), attributes, loc,
-							decl, isMacroExpansion));
-			} else
-				stack.push(builder.DeclSpecifier_enum(modifiers, name, enumerators.done(), attributes, loc, decl,
-						isMacroExpansion));
-		} else {
-			baseType.accept(this);
-			if (declSpec.isScoped()) {
-				if (declSpec.isOpaque())
-					stack.push(builder.DeclSpecifier_enumScopedOpaque(modifiers, stack.pop(), name, attributes, loc,
-							decl, isMacroExpansion));
-				else
-					stack.push(builder.DeclSpecifier_enumScoped(modifiers, stack.pop(), name, enumerators.done(),
-							attributes, loc, decl, isMacroExpansion));
-			} else {
-				if (declSpec.isOpaque())
-					stack.push(builder.DeclSpecifier_enumOpaque(modifiers, stack.pop(), name, attributes, loc, decl,
-							isMacroExpansion));
-				else
-					stack.push(builder.DeclSpecifier_enum(modifiers, stack.pop(), name, enumerators.done(), attributes,
-							loc, decl, isMacroExpansion));
-			}
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTNamedTypeSpecifier declSpec) {
-		out("CPPNamedTypeSpecifier: " + declSpec.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-	}
-
-	public int visit(ICPPASTSimpleDeclSpecifier declSpec) {
-		ISourceLocation loc = getSourceLocation(declSpec);
-		boolean isMacroExpansion = isMacroExpansion(declSpec);
-		IConstructor typ = tr.resolveType(declSpec);
-		IList attributes = getAttributes(declSpec);
-		IList modifiers = getModifiers(declSpec);
-
-		switch (declSpec.getType()) {
-		case IASTSimpleDeclSpecifier.t_unspecified: {
-			ISourceLocation location = null;
-			if (modifiers.isEmpty()) {
-				location = vf.sourceLocation(loc, loc.getOffset(), 0);
-			} else {
-				ISourceLocation before = (ISourceLocation) modifiers.get(modifiers.size() - 1).asWithKeywordParameters()
-						.getParameter("src");
-				location = vf.sourceLocation(before, before.getOffset() + before.getLength(), 0);
-			}
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_unspecified(location, isMacroExpansion), attributes, loc, isMacroExpansion));
-			break;
-		}
-		case IASTSimpleDeclSpecifier.t_void:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_void(getTokenSourceLocation(declSpec, "void"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_char:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_char(getTokenSourceLocation(declSpec, "char"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_int:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_integer(getTokenSourceLocation(declSpec, "int"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_float:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_float(getTokenSourceLocation(declSpec, "float"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_double:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_double(getTokenSourceLocation(declSpec, "double"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_bool:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_bool(getTokenSourceLocation(declSpec, "bool"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_wchar_t:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_wchar_t(getTokenSourceLocation(declSpec, "wchar_t"), isMacroExpansion), attributes,
-					loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_typeof:
-			declSpec.getDeclTypeExpression().accept(this);
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_typeof(getTokenSourceLocation(declSpec, "typeof"), isMacroExpansion), stack.pop(),
-					attributes, loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_decltype:
-			declSpec.getDeclTypeExpression().accept(this);
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_decltype(getTokenSourceLocation(declSpec, "decltype"), isMacroExpansion), stack.pop(),
-					attributes, loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_auto:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_auto(getTokenSourceLocation(declSpec, "auto"), isMacroExpansion), attributes, loc,
-					isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_char16_t:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_char16_t(getTokenSourceLocation(declSpec, "char16_t"), isMacroExpansion), attributes,
-					loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_char32_t:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_char32_t(getTokenSourceLocation(declSpec, "char32_t"), isMacroExpansion), attributes,
-					loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_int128:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_int128(getTokenSourceLocation(declSpec, "__int128"), isMacroExpansion), attributes,
-					loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_float128:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_float128(getTokenSourceLocation(declSpec, "__float128"), isMacroExpansion), attributes,
-					loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_decimal32:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_decimal128(getTokenSourceLocation(declSpec, "_Decimal32"), isMacroExpansion),
-					attributes, loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_decimal64:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_decimal64(getTokenSourceLocation(declSpec, "_Decimal64"), isMacroExpansion),
-					attributes, loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_decimal128:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
-					builder.Type_decimal128(getTokenSourceLocation(declSpec, "_Decimal128"), isMacroExpansion),
-					attributes, loc, isMacroExpansion));
-			break;
-		case IASTSimpleDeclSpecifier.t_decltype_auto:
-			stack.push(builder.DeclSpecifier_declSpecifier(modifiers, builder.Type_declTypeAuto(loc, isMacroExpansion),
-					attributes, loc, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Unknown IASTSimpleDeclSpecifier kind " + declSpec.getType() + " at " + loc + ". Exiting");
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTypeTransformationSpecifier declSpec) {
-		// TODO: implement, check operator and operand
-		err("ICPPASTTypeTransformationSpecifier: " + declSpec.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
-	}
-
-	@Override
-	public int visit(IASTArrayModifier arrayModifier) {
-		if (arrayModifier instanceof ICASTArrayModifier)
-			throw new RuntimeException("NYI at " + getSourceLocation(arrayModifier));
-		ISourceLocation loc = getSourceLocation(arrayModifier);
-		boolean isMacroExpansion = isMacroExpansion(arrayModifier);
-		IList attributes = getAttributes(arrayModifier);
-
-		IASTExpression constantExpression = arrayModifier.getConstantExpression();
-		if (constantExpression == null)
-			stack.push(builder.Expression_arrayModifier(attributes, loc, isMacroExpansion));
-		else {
-			constantExpression.accept(this);
-			stack.push(builder.Expression_arrayModifier(stack.pop(), attributes, loc, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTPointerOperator ptrOperator) {
-		if (ptrOperator instanceof IASTPointer)
-			visit((IASTPointer) ptrOperator);
-		else if (ptrOperator instanceof ICPPASTReferenceOperator)
-			visit((ICPPASTReferenceOperator) ptrOperator);
-		else
-			throw new RuntimeException("Unknown IASTPointerOperator subtype +" + ptrOperator.getClass().getName()
-					+ " at " + getSourceLocation(ptrOperator) + ". Exiting");
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTPointer pointer) {
-		ISourceLocation loc = getSourceLocation(pointer);
-		boolean isMacroExpansion = isMacroExpansion(pointer);
-		IList attributes = getAttributes(pointer);
-		IList modifiers = getModifiers(pointer);
-		if (pointer instanceof ICPPASTPointerToMember) {
-			ISourceLocation decl = br.resolveBinding(((ICPPASTPointerToMember) pointer));
-			((ICPPASTPointerToMember) pointer).getName().accept(this);
-			stack.push(builder.Declaration_pointerToMember(modifiers, stack.pop(), attributes, loc, decl,
-					isMacroExpansion));
-		} else
-			stack.push(builder.Declaration_pointer(modifiers, attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTReferenceOperator referenceOperator) {
-		ISourceLocation loc = getSourceLocation(referenceOperator);
-		boolean isMacroExpansion = isMacroExpansion(referenceOperator);
-		IList attributes = getAttributes(referenceOperator);
-		if (referenceOperator.isRValueReference())
-			stack.push(builder.Declaration_rvalueReference(attributes, loc, isMacroExpansion));
-		else
-			stack.push(builder.Declaration_reference(attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTAttribute attribute) {
-		ISourceLocation src = getSourceLocation(attribute);
-		if (attribute.getArgumentClause() == null || attribute.getArgumentClause().getTokenCharImage() == null)
-			stack.push(builder.Attribute_attribute(new String(attribute.getName()), src));
-		else
-			stack.push(builder.Attribute_attribute(new String(attribute.getName()),
-					new String(attribute.getArgumentClause().getTokenCharImage()), src));
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTAttributeSpecifier specifier) {
-		ISourceLocation src = getSourceLocation(specifier);
-		if (specifier instanceof ICPPASTAlignmentSpecifier) {
-			IASTExpression expression = ((ICPPASTAlignmentSpecifier) specifier).getExpression();
-			if (expression != null)
-				expression.accept(this);
-			else
-				((ICPPASTAlignmentSpecifier) specifier).getTypeId().accept(this);
-			stack.push(builder.Attribute_alignmentSpecifier(stack.pop(), src));
-		} else if (specifier instanceof IASTAttributeList) {
-			IASTAttributeList list = (IASTAttributeList) specifier;
-			IListWriter attributes = vf.listWriter();
-			Stream.of(list.getAttributes()).forEach(it -> {
-				it.accept(this);
-				attributes.append(stack.pop());
-			});
-			if (specifier instanceof IMSASTDeclspecList)
-				stack.push(builder.Attribute_msDeclspecList(attributes.done(), src));
-			else if (specifier instanceof IGCCASTAttributeList)
-				stack.push(builder.Attribute_gccAttributeList(attributes.done(), src));
-			else
-				stack.push(builder.Attribute_attributeSpecifier(attributes.done(), src));
-		} else {
-			throw new RuntimeException(
-					"Unknown AttributeSpecifier type: " + specifier.getClass().getSimpleName() + " at " + src);
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTToken token) {
-		err("Token: " + new String(token.getTokenCharImage()));
-		throw new RuntimeException("NYI at " + getSourceLocation(token));
-	}
-
-	@Override
-	public int visit(IASTExpression expression) {
-		if (expression instanceof IASTArraySubscriptExpression)
-			visit((IASTArraySubscriptExpression) expression);
-		else if (expression instanceof IASTBinaryExpression)
-			visit((IASTBinaryExpression) expression);
-		else if (expression instanceof IASTBinaryTypeIdExpression)
-			visit((IASTBinaryTypeIdExpression) expression);
-		else if (expression instanceof IASTCastExpression)
-			visit((IASTCastExpression) expression);
-		else if (expression instanceof IASTConditionalExpression)
-			visit((IASTConditionalExpression) expression);
-		else if (expression instanceof IASTExpressionList)
-			visit((IASTExpressionList) expression);
-		else if (expression instanceof IASTFieldReference)
-			visit((IASTFieldReference) expression);
-		else if (expression instanceof IASTFunctionCallExpression)
-			visit((IASTFunctionCallExpression) expression);
-		else if (expression instanceof IASTIdExpression)
-			visit((IASTIdExpression) expression);
-		else if (expression instanceof IASTLiteralExpression)
-			visit((IASTLiteralExpression) expression);
-		else if (expression instanceof IASTTypeIdExpression)
-			visit((IASTTypeIdExpression) expression);
-		else if (expression instanceof IASTTypeIdInitializerExpression)
-			visit((IASTTypeIdInitializerExpression) expression);
-		else if (expression instanceof IASTUnaryExpression)
-			visit((IASTUnaryExpression) expression);
-		else if (expression instanceof ICPPASTArraySubscriptExpression)
-			visit((ICPPASTArraySubscriptExpression) expression);
-		else if (expression instanceof ICPPASTBinaryExpression)
-			visit((ICPPASTBinaryExpression) expression);
-		else if (expression instanceof ICPPASTCastExpression)
-			visit((ICPPASTCastExpression) expression);
-		else if (expression instanceof ICPPASTDeleteExpression)
-			visit((ICPPASTDeleteExpression) expression);
-		else if (expression instanceof ICPPASTExpressionList)
-			visit((ICPPASTExpressionList) expression);
-		else if (expression instanceof ICPPASTFieldReference)
-			visit((ICPPASTFieldReference) expression);
-		else if (expression instanceof ICPPASTFunctionCallExpression)
-			visit((ICPPASTFunctionCallExpression) expression);
-		else if (expression instanceof ICPPASTLambdaExpression)
-			visit((ICPPASTLambdaExpression) expression);
-		else if (expression instanceof ICPPASTLiteralExpression)
-			visit((ICPPASTLiteralExpression) expression);
-		else if (expression instanceof ICPPASTNaryTypeIdExpression)
-			visit((ICPPASTNaryTypeIdExpression) expression);
-		else if (expression instanceof ICPPASTNewExpression)
-			visit((ICPPASTNewExpression) expression);
-		else if (expression instanceof ICPPASTPackExpansionExpression)
-			visit((ICPPASTPackExpansionExpression) expression);
-		else if (expression instanceof ICPPASTSimpleTypeConstructorExpression)
-			visit((ICPPASTSimpleTypeConstructorExpression) expression);
-		else if (expression instanceof ICPPASTTypeIdExpression)
-			visit((ICPPASTTypeIdExpression) expression);
-		else if (expression instanceof ICPPASTUnaryExpression)
-			visit((ICPPASTUnaryExpression) expression);
-		else if (expression instanceof IASTProblemExpression)
-			// Should not happen
-			visit((IASTProblemExpression) expression);
-		else if (expression instanceof CPPASTCompoundStatementExpression)
-			visit((CPPASTCompoundStatementExpression) expression);
-		else {
-			throw new RuntimeException("Expression: encountered non-implemented subtype "
-					+ expression.getClass().getName() + " at " + getSourceLocation(expression));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTArraySubscriptExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getArrayExpression().accept(this);
-		IConstructor arrayExpression = stack.pop();
-		expression.getArgument().accept(this);
-		IConstructor argument = stack.pop();
-
-		stack.push(builder.Expression_arraySubscriptExpression(arrayExpression, argument, loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTBinaryExpression expression) {
-		out("CPPBinaryExpression: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTCastExpression expression) {
-		out("CPPCastExpression: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTDeleteExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		expression.getOperand().accept(this);
-		if (expression.isGlobal()) {
-			if (expression.isVectored())
-				stack.push(builder.Expression_globalVectoredDelete(stack.pop(), loc, typ, isMacroExpansion));
-			else
-				stack.push(builder.Expression_globalDelete(stack.pop(), loc, typ, isMacroExpansion));
-		} else {
-			if (expression.isVectored())
-				stack.push(builder.Expression_vectoredDelete(stack.pop(), loc, typ, isMacroExpansion));
-			else
-				stack.push(builder.Expression_delete(stack.pop(), loc, typ, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTExpressionList expression) {
-		// has typ
-		out("CPPExpressionList: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTFieldReference expression) {
-		// has typ
-		out("CPPFieldReference: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTFunctionCallExpression expression) {
-		// has typ
-		out("CPPFunctionCallExpression: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTLambdaExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		ISourceLocation decl = br.UNKNOWN;
-		IConstructor typ = tr.resolveType(expression);
-		CaptureDefault captureDefault = expression.getCaptureDefault();
-
-		IListWriter captures = vf.listWriter();
-		Stream.of(expression.getCaptures()).forEach(it -> {
-			it.accept(this);
-			captures.append(stack.pop());
-		});
-
-		IConstructor declarator;
-		if (expression.getDeclarator() == null) {
-			ISourceLocation endOfCapture = getTokenSourceLocation(expression, "]");
-			declarator = builder.Declarator_missingDeclarator(
-					vf.sourceLocation(endOfCapture, endOfCapture.getOffset() + 1, 0), decl, isMacroExpansion);
-		} else {
-			expression.getDeclarator().accept(this);
-			declarator = stack.pop();
-		}
-
-		expression.getBody().accept(this);
-		IConstructor body = stack.pop();
-
-		switch (captureDefault) {
-		case BY_COPY:
-			stack.push(builder.Expression_lambda(
-					builder.Modifier_captDefByCopy(getTokenSourceLocation(expression, "="), isMacroExpansion),
-					captures.done(), declarator, body, loc, typ, isMacroExpansion));
-			break;
-		case BY_REFERENCE:
-			stack.push(builder.Expression_lambda(
-					builder.Modifier_captDefByReference(getTokenSourceLocation(expression, "&"), isMacroExpansion),
-					captures.done(), declarator, body, loc, typ, isMacroExpansion));
-			break;
-		case UNSPECIFIED:
-			stack.push(builder.Expression_lambda(
-					builder.Modifier_captDefUnspecified(vf.sourceLocation(loc, loc.getOffset(), 0), isMacroExpansion),
-					captures.done(), declarator, body, loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("Unknown default capture type " + captureDefault + " encountered at "
-					+ getSourceLocation(expression) + ", exiting");
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTLiteralExpression expression) {
-		// This may never be reached
-		visit((IASTLiteralExpression) expression);
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTNaryTypeIdExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		IListWriter args = vf.listWriter();
-		Stream.of(expression.getOperands()).forEach(it -> {
-			it.accept(this);
-			args.append(stack.pop());
-		});
-		switch (expression.getOperator()) {
-		case __is_constructible:
-			stack.push(builder.Expression_isConstructable(args.done(), loc, typ, isMacroExpansion));
-			return PROCESS_ABORT;
-		case __is_trivially_constructible:
-			stack.push(builder.Expression_isTriviallyConstructable(args.done(), loc, typ, isMacroExpansion));
-			return PROCESS_ABORT;
-		default:
-			throw new RuntimeException("Operator " + expression.getOperator() + " unknown at " + loc + ", exiting");
-		}
-	}
-
-	public int visit(ICPPASTNewExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		// if (expression.isNewTypeId())
-		// err("WARNING: ICPPASTNewExpression \"" + expression.getRawSignature()
-		// + "\" has isNewTypeId=true");
-		// else
-		// err("WARNING: ICPPASTNewExpression \"" + expression.getRawSignature()
-		// + "\" has isNewTypeId=false");
-
-		expression.getTypeId().accept(this);
-		IConstructor typeId = stack.pop();
-
-		IASTInitializerClause[] _placementArguments = expression.getPlacementArguments();
-		IASTInitializer _initializer = expression.getInitializer();
-		if (_placementArguments != null) {
-			IListWriter placementArguments = vf.listWriter();
-			Stream.of(_placementArguments).forEach(it -> {
-				it.accept(this);
-				placementArguments.append(stack.pop());
-			});
-			if (_initializer == null) {
-				if (expression.isGlobal())
-					stack.push(builder.Expression_globalNewWithArgs(placementArguments.done(), typeId, loc, typ,
-							isMacroExpansion));
-				else
-					stack.push(builder.Expression_newWithArgs(placementArguments.done(), typeId, loc, typ,
-							isMacroExpansion));
-			} else {
-				_initializer.accept(this);
-				if (expression.isGlobal())
-					stack.push(builder.Expression_globalNewWithArgs(placementArguments.done(), typeId, stack.pop(), loc,
-							typ, isMacroExpansion));
-				else
-					stack.push(builder.Expression_newWithArgs(placementArguments.done(), typeId, stack.pop(), loc, typ,
-							isMacroExpansion));
-			}
-		} else if (_initializer == null) {
-			if (expression.isGlobal())
-				stack.push(builder.Expression_globalNew(typeId, loc, typ, isMacroExpansion));
-			else
-				stack.push(builder.Expression_new(typeId, loc, typ, isMacroExpansion));
-		} else {
-			_initializer.accept(this);
-			if (expression.isGlobal())
-				stack.push(builder.Expression_globalNew(typeId, stack.pop(), loc, typ, isMacroExpansion));
-			else
-				stack.push(builder.Expression_new(typeId, stack.pop(), loc, typ, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTPackExpansionExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		expression.getPattern().accept(this);
-		stack.push(builder.Expression_packExpansion(stack.pop(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTSimpleTypeConstructorExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getDeclSpecifier().accept(this);
-		IConstructor declSpecifier = stack.pop();
-		expression.getInitializer().accept(this);
-		IConstructor initializer = stack.pop();
-
-		stack.push(builder.Expression_simpleTypeConstructor(declSpecifier, initializer, loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTypeIdExpression expression) {
-		// has typ
-		out("CPPTypeIdExpression: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(ICPPASTUnaryExpression expression) {
-		out("CPPUnaryExpression: " + expression.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(expression));
-	}
-
-	public int visit(CPPASTCompoundStatementExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ;
-		try {
-			typ = tr.resolveType(expression);
-		} catch (Throwable t) {
-			err("CPPASTCompoundStatement couldn't get type at " + loc);
-			t.printStackTrace(ctx.getErrorPrinter());
-			typ = builder.TypeSymbol_any();
-		}
-		expression.getCompoundStatement().accept(this);
-		stack.push(builder.Expression_compoundStatementExpression(stack.pop(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTArraySubscriptExpression expression) {
-		if (expression instanceof ICPPASTArraySubscriptExpression)
-			visit((ICPPASTArraySubscriptExpression) expression);
-		else
-			throw new RuntimeException("NYI at " + getSourceLocation(expression));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTBinaryExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getOperand1().accept(this);
-		IConstructor lhs = stack.pop();
-		expression.getInitOperand2().accept(this);
-		IConstructor rhs = stack.pop();
-
-		switch (expression.getOperator()) {
-		case IASTBinaryExpression.op_multiply:
-			stack.push(builder.Expression_multiply(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_divide:
-			stack.push(builder.Expression_divide(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_modulo:
-			stack.push(builder.Expression_modulo(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_plus:
-			stack.push(builder.Expression_plus(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_minus:
-			stack.push(builder.Expression_minus(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_shiftLeft:
-			stack.push(builder.Expression_shiftLeft(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_shiftRight:
-			stack.push(builder.Expression_shiftRight(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_lessThan:
-			stack.push(builder.Expression_lessThan(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_greaterThan:
-			stack.push(builder.Expression_greaterThan(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_lessEqual:
-			stack.push(builder.Expression_lessEqual(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_greaterEqual:
-			stack.push(builder.Expression_greaterEqual(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryAnd:
-			stack.push(builder.Expression_binaryAnd(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryXor:
-			stack.push(builder.Expression_binaryXor(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryOr:
-			stack.push(builder.Expression_binaryOr(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_logicalAnd:
-			stack.push(builder.Expression_logicalAnd(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_logicalOr:
-			stack.push(builder.Expression_logicalOr(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_assign:
-			stack.push(builder.Expression_assign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_multiplyAssign:
-			stack.push(builder.Expression_multiplyAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_divideAssign:
-			stack.push(builder.Expression_divideAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_moduloAssign:
-			stack.push(builder.Expression_moduloAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_plusAssign:
-			stack.push(builder.Expression_plusAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_minusAssign:
-			stack.push(builder.Expression_minusAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_shiftLeftAssign:
-			stack.push(builder.Expression_shiftLeftAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_shiftRightAssign:
-			stack.push(builder.Expression_shiftRightAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryAndAssign:
-			stack.push(builder.Expression_binaryAndAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryXorAssign:
-			stack.push(builder.Expression_binaryXorAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_binaryOrAssign:
-			stack.push(builder.Expression_binaryOrAssign(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_equals:
-			stack.push(builder.Expression_equals(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_notequals:
-			stack.push(builder.Expression_notEquals(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_pmdot:
-			stack.push(builder.Expression_pmDot(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_pmarrow:
-			stack.push(builder.Expression_pmArrow(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_max:
-			stack.push(builder.Expression_max(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_min:
-			stack.push(builder.Expression_min(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case IASTBinaryExpression.op_ellipses:
-			stack.push(builder.Expression_ellipses(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("Operator " + expression.getOperator() + " unknown at " + loc + ", exiting");
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTBinaryTypeIdExpression expression) {
-		// has typ
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getOperand1().accept(this);
-		IConstructor lhs = stack.pop();
-		expression.getOperand2().accept(this);
-		IConstructor rhs = stack.pop();
-
-		switch (expression.getOperator()) {
-		case __is_base_of:
-			stack.push(builder.Expression_isBaseOf(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		case __is_trivially_assignable:
-			stack.push(builder.Expression_isTriviallyAssignable(lhs, rhs, loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Unknown binary TypeId expression " + expression.getOperator().name() + " at " + loc);
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTCastExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getOperand().accept(this);
-		IConstructor operand = stack.pop();
-		expression.getTypeId().accept(this);
-		IConstructor type = stack.pop();
-
-		switch (expression.getOperator()) {
-		case ICPPASTCastExpression.op_cast:
-			stack.push(builder.Expression_cast(type, operand, loc, typ, isMacroExpansion));
-			break;
-		case ICPPASTCastExpression.op_dynamic_cast:
-			stack.push(builder.Expression_dynamicCast(type, operand, loc, typ, isMacroExpansion));
-			break;
-		case ICPPASTCastExpression.op_static_cast:
-			stack.push(builder.Expression_staticCast(type, operand, loc, typ, isMacroExpansion));
-			break;
-		case ICPPASTCastExpression.op_reinterpret_cast:
-			stack.push(builder.Expression_reinterpretCast(type, operand, loc, typ, isMacroExpansion));
-			break;
-		case ICPPASTCastExpression.op_const_cast:
-			stack.push(builder.Expression_constCast(type, operand, loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("Unknown cast type " + expression.getOperator() + " at " + loc);
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTConditionalExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getLogicalConditionExpression().accept(this);
-		IConstructor condition = stack.pop();
-		expression.getPositiveResultExpression().accept(this);
-		IConstructor positive = stack.pop();
-		expression.getNegativeResultExpression().accept(this);
-		IConstructor negative = stack.pop();
-
-		stack.push(builder.Expression_conditional(condition, positive, negative, loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTExpressionList expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		IListWriter expressions = vf.listWriter();
-		Stream.of(expression.getExpressions()).forEach(it -> {
-			it.accept(this);
-			expressions.append(stack.pop());
-		});
-		stack.push(builder.Expression_expressionList(expressions.done(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTFieldReference expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		if (expression instanceof ICPPASTFieldReference) {
-			// TODO: implement isTemplate
-			boolean isMacroExpansion = isMacroExpansion(expression);
-			ISourceLocation decl = br.resolveBinding(expression);
-			IConstructor typ = tr.resolveType(expression);
-
-			expression.getFieldOwner().accept(this);
-			IConstructor fieldOwner = stack.pop();
-			expression.getFieldName().accept(this);
-			IConstructor fieldName = stack.pop();
-
-			if (expression.isPointerDereference())
-				stack.push(builder.Expression_fieldReferencePointerDeref(fieldOwner, fieldName, loc, decl, typ,
-						isMacroExpansion));
-			else
-				stack.push(builder.Expression_fieldReference(fieldOwner, fieldName, loc, decl, typ, isMacroExpansion));
-		} else
-			throw new RuntimeException("IASTFieldReference: NYI at " + loc);
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTFunctionCallExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getFunctionNameExpression().accept(this);
-		IConstructor functionName = stack.pop();
-
-		IListWriter arguments = vf.listWriter();
-		Stream.of(expression.getArguments()).forEach(it -> {
-			it.accept(this);
-			arguments.append(stack.pop());
-		});
-		stack.push(builder.Expression_functionCall(functionName, arguments.done(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTIdExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		ISourceLocation decl = br.resolveBinding(expression);
-		IConstructor typ = tr.resolveType(expression);
-		expression.getName().accept(this);
-		stack.push(builder.Expression_idExpression(stack.pop(), loc, decl, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTLiteralExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		String value = new String(expression.getValue());
-		switch (expression.getKind()) {
-		case IASTLiteralExpression.lk_integer_constant:
-			stack.push(builder.Expression_integerConstant(value, loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_float_constant:
-			stack.push(builder.Expression_floatConstant(value, loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_char_constant:
-			stack.push(builder.Expression_charConstant(value, loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_string_literal:
-			stack.push(builder.Expression_stringLiteral(value, loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_this:
-			stack.push(builder.Expression_this(loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_true:
-			stack.push(builder.Expression_true(loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_false:
-			stack.push(builder.Expression_false(loc, typ, isMacroExpansion));
-			break;
-		case IASTLiteralExpression.lk_nullptr:
-			stack.push(builder.Expression_nullptr(loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Encountered unknown literal kind " + expression.getKind() + " at " + loc + ". Exiting");
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTProblemExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IASTProblem problem = expression.getProblem();
-		if (doProblemLogging)
-			err("ProblemExpression " + expression.getRawSignature() + ":" + problem.getMessageWithLocation());
-		stack.push(builder.Expression_problemExpression(loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTTypeIdInitializerExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-		expression.getTypeId().accept(this);
-		IConstructor typeId = stack.pop();
-		expression.getInitializer().accept(this);
-		stack.push(builder.Expression_typeIdInitializerExpression(typeId, stack.pop(), loc, typ, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTTypeIdExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		expression.getTypeId().accept(this);
-		switch (expression.getOperator()) {
-		case IASTTypeIdExpression.op_sizeof:
-			stack.push(builder.Expression_sizeof(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_typeid:
-			stack.push(builder.Expression_typeid(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_alignof: // gnu-only?
-			stack.push(builder.Expression_alignOf(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_typeof:
-			stack.push(builder.Expression_typeof(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_nothrow_assign:
-			stack.push(builder.Expression_hasNothrowAssign(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_nothrow_copy:
-			stack.push(builder.Expression_hasNothrowCopy(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_nothrow_constructor:
-			stack.push(builder.Expression_hasNothrowConstructor(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_trivial_assign:
-			stack.push(builder.Expression_hasTrivialAssign(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_trivial_constructor:
-			stack.push(builder.Expression_hasTrivialConstructor(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_trivial_copy:
-			stack.push(builder.Expression_hasTrivialCopy(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_trivial_destructor:
-			stack.push(builder.Expression_hasTrivialDestructor(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_has_virtual_destructor:
-			stack.push(builder.Expression_hasVirtualDestructor(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_abstract:
-			stack.push(builder.Expression_isAbstract(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_class:
-			stack.push(builder.Expression_isClass(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_empty:
-			stack.push(builder.Expression_isEmpty(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_enum:
-			stack.push(builder.Expression_isEnum(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_pod:
-			stack.push(builder.Expression_isPod(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_polymorphic:
-			stack.push(builder.Expression_isPolymorphic(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_union:
-			stack.push(builder.Expression_isUnion(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_literal_type:
-			stack.push(builder.Expression_isLiteralType(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_standard_layout:
-			stack.push(builder.Expression_isStandardLayout(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_trivial:
-			stack.push(builder.Expression_isTrivial(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_sizeofParameterPack:
-			stack.push(builder.Expression_sizeofParameterPack(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_final:
-			stack.push(builder.Expression_isFinal(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		case IASTTypeIdExpression.op_is_trivially_copyable:
-			stack.push(builder.Expression_isTriviallyCopyable(stack.pop(), loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("ERROR: IASTTypeIdExpression called with unimplemented/unknown operator "
-					+ expression.getOperator() + " at " + loc);
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTUnaryExpression expression) {
-		ISourceLocation loc = getSourceLocation(expression);
-		boolean isMacroExpansion = isMacroExpansion(expression);
-		IConstructor typ = tr.resolveType(expression);
-
-		IConstructor operand = null;
-		if (expression.getOperand() != null) {
-			expression.getOperand().accept(this);
-			operand = stack.pop();
-		}
-
-		switch (expression.getOperator()) {
-		case IASTUnaryExpression.op_prefixIncr:
-			stack.push(builder.Expression_prefixIncr(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_prefixDecr:
-			stack.push(builder.Expression_prefixDecr(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_plus:
-			stack.push(builder.Expression_plus(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_minus:
-			stack.push(builder.Expression_minus(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_star:
-			stack.push(builder.Expression_star(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_amper:
-			stack.push(builder.Expression_amper(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_tilde:
-			stack.push(builder.Expression_tilde(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_not:
-			stack.push(builder.Expression_not(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_sizeof:
-			stack.push(builder.Expression_sizeof(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_postFixIncr:
-			stack.push(builder.Expression_postfixIncr(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_postFixDecr:
-			stack.push(builder.Expression_postfixDecr(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_bracketedPrimary:
-			stack.push(builder.Expression_bracketed(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_throw:
-			if (operand == null)
-				stack.push(builder.Expression_throw(loc, typ, isMacroExpansion));
-			else
-				stack.push(builder.Expression_throw(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_typeid:
-			stack.push(builder.Expression_typeid(operand, loc, typ, isMacroExpansion));
-			break;
-		// case IASTUnaryExpression.op_typeof: (14) typeOf is deprecated
-		case IASTUnaryExpression.op_alignOf:
-			stack.push(builder.Expression_alignOf(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_sizeofParameterPack:
-			stack.push(builder.Expression_sizeofParameterPack(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_noexcept:
-			stack.push(builder.Expression_noexcept(operand, loc, typ, isMacroExpansion));
-			break;
-		case IASTUnaryExpression.op_labelReference:
-			stack.push(builder.Expression_labelReference(operand, loc, typ, isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Unknown unary operator " + expression.getOperator() + " at " + loc + ". Exiting");
-		}
-
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTStatement statement) {
-		if (statement instanceof IASTAmbiguousStatement)
-			visit((IASTAmbiguousStatement) statement);
-		else if (statement instanceof IASTBreakStatement)
-			visit((IASTBreakStatement) statement);
-		else if (statement instanceof IASTCaseStatement)
-			visit((IASTCaseStatement) statement);
-		else if (statement instanceof IASTCompoundStatement)
-			visit((IASTCompoundStatement) statement);
-		else if (statement instanceof IASTContinueStatement)
-			visit((IASTContinueStatement) statement);
-		else if (statement instanceof IASTDeclarationStatement)
-			visit((IASTDeclarationStatement) statement);
-		else if (statement instanceof IASTDefaultStatement)
-			visit((IASTDefaultStatement) statement);
-		else if (statement instanceof IASTDoStatement)
-			visit((IASTDoStatement) statement);
-		else if (statement instanceof IASTExpressionStatement)
-			visit((IASTExpressionStatement) statement);
-		else if (statement instanceof IASTForStatement)
-			visit((IASTForStatement) statement);
-		else if (statement instanceof IASTGotoStatement)
-			visit((IASTGotoStatement) statement);
-		else if (statement instanceof IASTIfStatement)
-			visit((IASTIfStatement) statement);
-		else if (statement instanceof IASTLabelStatement)
-			visit((IASTLabelStatement) statement);
-		else if (statement instanceof IASTNullStatement)
-			visit((IASTNullStatement) statement);
-		else if (statement instanceof IASTReturnStatement)
-			visit((IASTReturnStatement) statement);
-		else if (statement instanceof IASTSwitchStatement)
-			visit((IASTSwitchStatement) statement);
-		else if (statement instanceof IASTWhileStatement)
-			visit((IASTWhileStatement) statement);
-		else if (statement instanceof ICPPASTCatchHandler)
-			visit((ICPPASTCatchHandler) statement);
-		else if (statement instanceof ICPPASTRangeBasedForStatement)
-			visit((ICPPASTRangeBasedForStatement) statement);
-		else if (statement instanceof ICPPASTTryBlockStatement)
-			visit((ICPPASTTryBlockStatement) statement);
-		else if (statement instanceof IGNUASTGotoStatement)
-			visit((IGNUASTGotoStatement) statement);
-		else if (statement instanceof IASTProblemStatement)
-			visit((IASTProblemStatement) statement);
-		else {
-			throw new RuntimeException("Statement: encountered non-implemented subtype "
-					+ statement.getClass().getName() + " at " + getSourceLocation(statement));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IGNUASTGotoStatement statement) {
-		// requires decl keyword parameter
-		err("IGNUAstGotoStatement: " + statement.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(statement));
-	}
-
-	public int visit(ICPPASTCatchHandler statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getCatchBody().accept(this);
-		IConstructor catchBody = stack.pop();
-
-		if (statement.isCatchAll())
-			stack.push(builder.Statement_catchAll(catchBody, attributes, loc, isMacroExpansion));
-		else {
-			statement.getDeclaration().accept(this);
-			stack.push(builder.Statement_catch(stack.pop(), catchBody, attributes, loc, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTRangeBasedForStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getDeclaration().accept(this);
-		IConstructor declaration = stack.pop();
-		statement.getInitializerClause().accept(this);
-		IConstructor initializerClause = stack.pop();
-		statement.getBody().accept(this);
-		IConstructor body = stack.pop();
-
-		stack.push(builder.Statement_rangeBasedFor(declaration, initializerClause, body, attributes, loc,
-				isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(ICPPASTTryBlockStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getTryBody().accept(this);
-		IConstructor tryBody = stack.pop();
-
-		IListWriter catchHandlers = vf.listWriter();
-		Stream.of(statement.getCatchHandlers()).forEach(it -> {
-			it.accept(this);
-			catchHandlers.append(stack.pop());
-		});
-
-		stack.push(builder.Statement_tryBlock(tryBody, catchHandlers.done(), attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTAmbiguousStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		out("visit(IASTAmbiguousStatement) " + loc);
-		out(statement.getRawSignature());
-		IListWriter statements = vf.listWriter();
-		prefix += 4;
-		Stream.of(statement.getStatements()).forEach(it -> {
-			out("Statement " + it.getClass().getSimpleName() + ": " + it.getRawSignature());
-			it.accept(this);
-			statements.append(stack.pop());
-		});
-		prefix -= 4;
-		throw new RuntimeException("Encountered Ambiguous statement at " + loc);
-	}
-
-	public int visit(IASTBreakStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		stack.push(builder.Statement_break(attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTCaseStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		statement.getExpression().accept(this);
-		IConstructor expression = stack.pop();
-		stack.push(builder.Statement_case(expression, attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTCompoundStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		IListWriter statements = vf.listWriter();
-		Stream.of(statement.getStatements()).forEach(it -> {
-			it.accept(this);
-			statements.append(stack.pop());
-		});
-		stack.push(builder.Statement_compoundStatement(statements.done(), attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTContinueStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		stack.push(builder.Statement_continue(attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTDeclarationStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		statement.getDeclaration().accept(this);
-		stack.push(builder.Statement_declarationStatement(stack.pop(), attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTDefaultStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		stack.push(builder.Statement_defaultCase(attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTDoStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getBody().accept(this);
-		IConstructor body = stack.pop();
-		statement.getCondition().accept(this);
-		IConstructor condition = stack.pop();
-		stack.push(builder.Statement_do(body, condition, attributes, loc, isMacroExpansion));
-
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTExpressionStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		statement.getExpression().accept(this);
-		stack.push(builder.Statement_expressionStatement(stack.pop(), attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTForStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		IASTStatement _initializer = statement.getInitializerStatement();
-		IConstructor initializer = null;
-		if (_initializer != null) {
-			_initializer.accept(this);
-			initializer = stack.pop();
-		}
-
-		IASTExpression _condition = statement.getConditionExpression();
-		IConstructor condition;
-		if (_condition == null) {
-			ISourceLocation initializerLoc = (ISourceLocation) initializer.asWithKeywordParameters()
-					.getParameter("src");
-			condition = builder.Expression_empty(
-					vf.sourceLocation(initializerLoc, initializerLoc.getOffset() + initializerLoc.getLength(), 0),
-					isMacroExpansion);
-		} else {
-			_condition.accept(this);
-			condition = stack.pop();
-		}
-
-		IASTExpression _iteration = statement.getIterationExpression();
-		IConstructor iteration;
-		if (_iteration == null) {
-			ISourceLocation conditionLoc = (ISourceLocation) condition.asWithKeywordParameters().getParameter("src");
-			iteration = builder.Expression_empty(
-					vf.sourceLocation(conditionLoc, conditionLoc.getOffset() + conditionLoc.getLength(), 0),
-					isMacroExpansion);
-		} else {
-			_iteration.accept(this);
-			iteration = stack.pop();
-		}
-
-		statement.getBody().accept(this);
-		IConstructor body = stack.pop();
-
-		if (statement instanceof ICPPASTForStatement) {
-			IASTDeclaration _conditionDeclaration = ((ICPPASTForStatement) statement).getConditionDeclaration();
-			if (_conditionDeclaration != null) {
-				_conditionDeclaration.accept(this);
-				stack.push(builder.Statement_forWithDecl(initializer, stack.pop(), iteration, body, attributes, loc,
-						isMacroExpansion));
-				return PROCESS_ABORT;
-			}
-		}
-		stack.push(builder.Statement_for(initializer, condition, iteration, body, attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTGotoStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		ISourceLocation decl = br.resolveBinding(statement);
-		IList attributes = getAttributes(statement);
-		statement.getName().accept(this);
-		stack.push(builder.Statement_goto(stack.pop(), attributes, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTIfStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getThenClause().accept(this);
-		IConstructor thenClause = stack.pop();
-
-		IConstructor elseClause = null;
-		if (statement.getElseClause() != null) {
-			statement.getElseClause().accept(this);
-			elseClause = stack.pop();
-		}
-
-		if (statement.getConditionExpression() == null && statement instanceof ICPPASTIfStatement) {
-			((ICPPASTIfStatement) statement).getConditionDeclaration().accept(this);
-			if (elseClause == null) {
-				stack.push(builder.Statement_ifWithDecl(stack.pop(), thenClause, attributes, loc, isMacroExpansion));
-			} else {
-				stack.push(builder.Statement_ifWithDecl(stack.pop(), thenClause, elseClause, attributes, loc,
-						isMacroExpansion));
-			}
-		} else {
-			statement.getConditionExpression().accept(this);
-			if (elseClause == null) {
-				stack.push(builder.Statement_if(stack.pop(), thenClause, attributes, loc, isMacroExpansion));
-			} else {
-				stack.push(
-						builder.Statement_if(stack.pop(), thenClause, elseClause, attributes, loc, isMacroExpansion));
-			}
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTLabelStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		ISourceLocation decl = br.resolveBinding(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getName().accept(this);
-		IConstructor name = stack.pop();
-		statement.getNestedStatement().accept(this);
-		IConstructor nestedStatement = stack.pop();
-
-		stack.push(builder.Statement_label(name, nestedStatement, attributes, loc, decl, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTNullStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		stack.push(builder.Statement_nullStatement(attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTProblemStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		if (doProblemLogging) {
-			err("IASTProblemStatement:");
-			prefix += 4;
-			err(statement.getProblem().getMessageWithLocation());
-			err("" + statement.getProblem().getID());
-			err(statement.getRawSignature());
-			prefix -= 4;
-		}
-		stack.push(builder.Statement_problem(statement.getRawSignature(), loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTReturnStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-		IASTExpression returnValue = statement.getReturnValue();
-		IASTInitializerClause returnArgument = statement.getReturnArgument();
-		if (returnValue == null && returnArgument == null)
-			stack.push(builder.Statement_return(attributes, loc, isMacroExpansion));
-		else if (returnValue != null) {
-			returnValue.accept(this);
-			stack.push(builder.Statement_return(stack.pop(), attributes, loc, isMacroExpansion));
-		} else {
-			returnArgument.accept(this);
-			// Note: InitializerClause is currently mapped on Expression
-			stack.push(builder.Statement_return(stack.pop(), attributes, loc, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTSwitchStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getBody().accept(this);
-		IConstructor body = stack.pop();
-
-		IASTExpression _controller = statement.getControllerExpression();
-		if (_controller == null && statement instanceof ICPPASTSwitchStatement) {
-			((ICPPASTSwitchStatement) statement).getControllerDeclaration().accept(this);
-			stack.push(builder.Statement_switchWithDecl(stack.pop(), body, attributes, loc, isMacroExpansion));
-			return PROCESS_ABORT;
-		}
-
-		_controller.accept(this);
-		stack.push(builder.Statement_switch(stack.pop(), body, attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	public int visit(IASTWhileStatement statement) {
-		ISourceLocation loc = getSourceLocation(statement);
-		boolean isMacroExpansion = isMacroExpansion(statement);
-		IList attributes = getAttributes(statement);
-
-		statement.getBody().accept(this);
-		IConstructor body = stack.pop();
-
-		IASTExpression _condition = statement.getCondition();
-		if (_condition == null && statement instanceof ICPPASTWhileStatement) {
-			((ICPPASTWhileStatement) statement).getConditionDeclaration().accept(this);
-			stack.push(builder.Statement_whileWithDecl(stack.pop(), body, attributes, loc, isMacroExpansion));
-			return PROCESS_ABORT;
-		}
-		_condition.accept(this);
-		stack.push(builder.Statement_while(stack.pop(), body, attributes, loc, isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTTypeId typeId) {
-		ISourceLocation loc = getSourceLocation(typeId);
-		boolean isMacroExpansion = isMacroExpansion(typeId);
-		if (typeId instanceof IASTProblemTypeId) {
-			if (typeId.getRawSignature().equals("...") || typeId.getRawSignature().contains("_THROW1("))
-				stack.push(builder.Expression_typeId(
-						builder.DeclSpecifier_msThrowEllipsis(loc, vf.sourceLocation("unknown:///"), false), loc,
-						isMacroExpansion));
-			else {
-				out("ProblemTypeId " + typeId.getClass().getSimpleName() + ": " + typeId.getRawSignature());
-				throw new RuntimeException("IASTProblemTypeId encountered at " + loc + "! "
-						+ ((IASTProblemTypeId) typeId).getProblem().getMessageWithLocation());
-			}
-		} else {
-			typeId.getDeclSpecifier().accept(this);
-			IConstructor declSpecifier = stack.pop();
-			typeId.getAbstractDeclarator().accept(this);
-			IConstructor abstractDeclarator = stack.pop();
-			if (abstractDeclarator.has("name")) {// TODO: properly fix
-				ISourceLocation declaratorLoc = getSourceLocation(typeId.getAbstractDeclarator());
-				abstractDeclarator = abstractDeclarator.set("name",
-						builder.Name_abstractEmptyName(declaratorLoc, false));
-				abstractDeclarator = abstractDeclarator.asWithKeywordParameters().unsetParameter("decl");
-			}
-			stack.push(builder.Expression_typeId(declSpecifier, abstractDeclarator, loc, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTEnumerator enumerator) {
-		ISourceLocation loc = getSourceLocation(enumerator);
-		boolean isMacroExpansion = isMacroExpansion(enumerator);
-		ISourceLocation decl = br.resolveBinding(enumerator);
-
-		enumerator.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		IASTExpression value = enumerator.getValue();
-		if (value == null)
-			stack.push(builder.Declaration_enumerator(name, loc, decl, isMacroExpansion));
-		else {
-			value.accept(this);
-			stack.push(builder.Declaration_enumerator(name, stack.pop(), loc, decl, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(IASTProblem problem) {
-		err("Problem: " + problem.getMessage());
-		throw new RuntimeException("NYI at " + getSourceLocation(problem));
-	}
-
-	@Override
-	public int visit(ICPPASTBaseSpecifier baseSpecifier) {
-		ISourceLocation loc = getSourceLocation(baseSpecifier);
-		boolean isMacroExpansion = isMacroExpansion(baseSpecifier);
-		ISourceLocation decl = br.resolveBinding(baseSpecifier);
-		IConstructor typ = tr.resolveType(baseSpecifier);
-
-		IListWriter modifiers = vf.listWriter();
-		switch (baseSpecifier.getVisibility()) {
-		case ICPPASTBaseSpecifier.v_public:
-			modifiers
-					.append(builder.Modifier_public(getTokenSourceLocation(baseSpecifier, "public"), isMacroExpansion));
-			break;
-		case ICPPASTBaseSpecifier.v_protected:
-			modifiers.append(
-					builder.Modifier_protected(getTokenSourceLocation(baseSpecifier, "protected"), isMacroExpansion));
-			break;
-		case ICPPASTBaseSpecifier.v_private:
-			modifiers.append(
-					builder.Modifier_private(getTokenSourceLocation(baseSpecifier, "private"), isMacroExpansion));
-			break;
-		case 0:
-			modifiers.append(builder.Modifier_unspecifiedInheritance(vf.sourceLocation(loc, loc.getOffset(), 0),
-					isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException(
-					"Unknown BaseSpecifier visibility code " + baseSpecifier.getVisibility() + " at " + loc);
-		}
-		if (baseSpecifier.isVirtual())
-			modifiers.append(
-					builder.Modifier_virtual(getTokenSourceLocation(baseSpecifier, "virtual"), isMacroExpansion));
-
-		ICPPASTNameSpecifier nameSpecifier = baseSpecifier.getNameSpecifier();
-		if (nameSpecifier == null)
-			stack.push(builder.Declaration_baseSpecifier(modifiers.done(), loc, decl, isMacroExpansion));
-		else {
-			nameSpecifier.accept(this);
-			stack.push(builder.Declaration_baseSpecifier(modifiers.done(), stack.pop(), loc, decl, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICPPASTNamespaceDefinition namespaceDefinition) {
-		ISourceLocation loc = getSourceLocation(namespaceDefinition);
-		boolean isMacroExpansion = isMacroExpansion(namespaceDefinition);
-		ISourceLocation decl = br.resolveBinding(namespaceDefinition);
-		IList attributes = getAttributes(namespaceDefinition);
-
-		namespaceDefinition.getName().accept(this);
-		IConstructor name = stack.pop();
-
-		IListWriter declarations = vf.listWriter();
-		Stream.of(namespaceDefinition.getDeclarations()).forEach(it -> {
-			it.accept(this);
-			declarations.append(stack.pop());
-		});
-
-		if (namespaceDefinition.isInline())
-			stack.push(builder.Declaration_namespaceDefinitionInline(name, declarations.done(), attributes, loc, decl,
-					isMacroExpansion));
-		else
-			stack.push(builder.Declaration_namespaceDefinition(name, declarations.done(), attributes, loc, decl,
-					isMacroExpansion));
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICPPASTTemplateParameter templateParameter) {
-		ISourceLocation loc = getSourceLocation(templateParameter);
-		boolean isMacroExpansion = isMacroExpansion(templateParameter);
-		// boolean isParameterPack = templateParameter.isParameterPack();
-		// if (isParameterPack)
-		// err("WARNING: ICPPASTTemplateParameter has isParameterPack=true,
-		// unimplemented");
-		if (templateParameter instanceof ICPPASTSimpleTypeTemplateParameter) {
-			ISourceLocation decl = br.resolveBinding((ICPPASTSimpleTypeTemplateParameter) templateParameter);
-			IConstructor typ = tr.resolveType(templateParameter);
-
-			ICPPASTSimpleTypeTemplateParameter parameter = (ICPPASTSimpleTypeTemplateParameter) templateParameter;
-			parameter.getName().accept(this);
-			IConstructor name = stack.pop();
-
-			if (parameter.getDefaultType() != null) {
-				parameter.getDefaultType().accept(this);
-				switch (parameter.getParameterType()) {
-				case ICPPASTSimpleTypeTemplateParameter.st_class:
-					stack.push(builder.Declaration_sttClass(name, stack.pop(), loc, decl, isMacroExpansion));
-					break;
-				case ICPPASTSimpleTypeTemplateParameter.st_typename:
-					stack.push(builder.Declaration_sttTypename(name, stack.pop(), loc, decl, isMacroExpansion));
-					break;
-				default:
-					throw new RuntimeException("ICPPASTTemplateParameter encountered non-implemented parameter type "
-							+ parameter.getParameterType() + " at " + loc);
-				}
-			} else {
-				switch (parameter.getParameterType()) {
-				case ICPPASTSimpleTypeTemplateParameter.st_class:
-					stack.push(builder.Declaration_sttClass(name, loc, decl, isMacroExpansion));
-					break;
-				case ICPPASTSimpleTypeTemplateParameter.st_typename:
-					stack.push(builder.Declaration_sttTypename(name, loc, decl, isMacroExpansion));
-					break;
-				default:
-					throw new RuntimeException("ICPPASTTemplateParameter encountered non-implemented parameter type "
-							+ parameter.getParameterType() + " at " + loc);
-				}
-			}
-		} else if (templateParameter instanceof ICPPASTTemplatedTypeTemplateParameter) {
-			ISourceLocation decl = br.resolveBinding((ICPPASTTemplatedTypeTemplateParameter) templateParameter);
-			IListWriter templateParameters = vf.listWriter();
-			Stream.of(((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getTemplateParameters())
-					.forEach(it -> {
-						it.accept(this);
-						templateParameters.append(stack.pop());
-					});
-			((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getName().accept(this);
-			IConstructor name = stack.pop();
-			IASTExpression defaultValue = ((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getDefaultValue();
-			if (defaultValue == null) {
-				stack.push(
-						builder.Declaration_tttParameter(templateParameters.done(), name, loc, decl, isMacroExpansion));
-			} else {
-				defaultValue.accept(this);
-				stack.push(builder.Declaration_tttParameterWithDefault(templateParameters.done(), name, stack.pop(),
-						loc, decl, isMacroExpansion));
-			}
-		} else
-			throw new RuntimeException("ICPPASTTemplateParameter encountered unknown subtype "
-					+ templateParameter.getClass().getName() + " at " + loc + ". Exiting");
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICPPASTCapture capture) {
-		// TODO: check isPackExpansion
-		ISourceLocation loc = getSourceLocation(capture);
-		boolean isMacroExpansion = isMacroExpansion(capture);
-		if (capture.capturesThisPointer())
-			stack.push(builder.Expression_captureThisPtr(loc, isMacroExpansion));
-		else {
-			ISourceLocation decl = br.resolveBinding(capture);
-			capture.getIdentifier().accept(this);
-			if (capture.isByReference())
-				stack.push(builder.Expression_captureByRef(stack.pop(), loc, decl, isMacroExpansion));
-			else
-				stack.push(builder.Expression_capture(stack.pop(), loc, decl, isMacroExpansion));
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICASTDesignator designator) {
-		err("Designator: " + designator.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(designator));
-	}
-
-	@Override
-	public int visit(ICPPASTDesignator designator) {
-		ISourceLocation loc = getSourceLocation(designator);
-		boolean isMacroExpansion = isMacroExpansion(designator);
-		if (designator instanceof ICPPASTArrayDesignator) {
-			((ICPPASTArrayDesignator) designator).getSubscriptExpression().accept(this);
-			stack.push(builder.Expression_arrayDesignator(stack.pop(), loc, isMacroExpansion));
-		} else if (designator instanceof ICPPASTFieldDesignator) {
-			((ICPPASTFieldDesignator) designator).getName().accept(this);
-			stack.push(builder.Expression_fieldDesignator(stack.pop(), loc, isMacroExpansion));
-		} else if (designator instanceof IGPPASTArrayRangeDesignator) {
-			((IGPPASTArrayRangeDesignator) designator).getRangeFloor().accept(this);
-			IConstructor rangeFloor = stack.pop();
-			((IGPPASTArrayRangeDesignator) designator).getRangeCeiling().accept(this);
-			IConstructor rangeCeiling = stack.pop();
-			stack.push(builder.Expression_arrayRangeDesignator(rangeFloor, rangeCeiling, loc, isMacroExpansion));
-		} else
-			throw new RuntimeException("ICPPASTDesignator encountered unknown subclass at " + loc + ", exiting");
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICPPASTVirtSpecifier virtSpecifier) {
-		ISourceLocation loc = getSourceLocation(virtSpecifier);
-		boolean isMacroExpansion = isMacroExpansion(virtSpecifier);
-		switch (virtSpecifier.getKind()) {
-		case Final:
-			stack.push(builder.Declaration_virtSpecifier(
-					builder.Modifier_final(getTokenSourceLocation(virtSpecifier, "final"), isMacroExpansion), loc,
-					isMacroExpansion));
-			break;
-		case Override:
-			stack.push(builder.Declaration_virtSpecifier(
-					builder.Modifier_override(getTokenSourceLocation(virtSpecifier, "override"), isMacroExpansion), loc,
-					isMacroExpansion));
-			break;
-		default:
-			throw new RuntimeException("ICPPASTVirtSpecifier encountered unknown SpecifierKind "
-					+ virtSpecifier.getKind().name() + " at " + loc);
-		}
-		return PROCESS_ABORT;
-	}
-
-	@Override
-	public int visit(ICPPASTClassVirtSpecifier classVirtSpecifier) {
-		err("ClassVirtSpecifier: " + classVirtSpecifier.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(classVirtSpecifier));
-	}
-
-	@Override
-	public int visit(ICPPASTDecltypeSpecifier decltypeSpecifier) {
-		// has typ
-		err("DecltypeSpecifier: " + decltypeSpecifier.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(decltypeSpecifier));
-	}
-
-	@Override
-	public int visit(ASTAmbiguousNode astAmbiguousNode) {
-		err("AstAmbiguousNode: " + astAmbiguousNode.getRawSignature());
-		throw new RuntimeException("NYI at " + getSourceLocation(astAmbiguousNode));
-	}
+    private final IValueFactory vf;
+    private final PrintWriter out;
+    private final PrintWriter err;
+    private final IRascalMonitor monitor;
+
+    private final AST builder;
+    private Stack<IConstructor> stack = new Stack<>();
+    private BindingsResolver br = new BindingsResolver();
+    private TypeResolver tr;
+
+    private boolean doProblemLogging = false;
+    private boolean toM3 = false;
+    private boolean includeStdLib = false;
+    private IList stdLib;
+
+    private ISetWriter declaredType;
+
+    public Parser(IValueFactory vf, PrintWriter out, PrintWriter err, IRascalMonitor monitor) {
+        super(true);
+        this.shouldVisitAmbiguousNodes = true;
+        this.shouldVisitImplicitNames = true;
+        this.includeInactiveNodes = true;
+        this.shouldVisitTokens = true;
+
+        this.vf = vf;
+        this.out = out;
+        this.err = err;
+        this.monitor = monitor;
+
+        this.builder = new AST(vf);
+        this.tr = new TypeResolver(builder, vf);
+        this.declaredType = vf.setWriter();
+    }
+
+    public IList parseFiles(IList files, IList stdLib, IList includeDirs, IMap additionalMacros, IBool includeStdLib) {
+        this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
+        this.stdLib = stdLib;
+
+        CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), vf, out, err);
+        Instant begin = Instant.now();
+        out("Beginning at " + begin.toString());
+        IListWriter asts = vf.listWriter();
+        for (IValue v : files) {
+            if (monitor.jobIsCanceled("")) {
+                break;
+            }
+            ISourceLocation file = (ISourceLocation) v;
+            IASTTranslationUnit tu = parser.parseFile(file);
+            IValue result = convertCdtToRascal(tu, false);
+            asts.append(result);
+        }
+        Instant done = Instant.now();
+        out("Parsing and marshalling " + files.size() + " files took "
+                + new Double(Duration.between(begin, done).toMillis()).doubleValue() / 1000 + "seconds");
+        return asts.done();
+    }
+
+    public IValue parseCpp(ISourceLocation file, IList stdLib, IList includeDirs, IMap additionalMacros,
+            IBool includeStdLib) {
+        this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
+        this.stdLib = stdLib;
+
+        Instant begin = Instant.now();
+        out("Beginning at " + begin.toString());
+        CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), vf, out, err);
+        IASTTranslationUnit tu = parser.parseFile(file);
+        Instant between = Instant.now();
+        out("CDT took " + new Double(Duration.between(begin, between).toMillis()).doubleValue() / 1000 + "seconds");
+        IValue result = convertCdtToRascal(tu, false);
+        Instant done = Instant.now();
+        out("Marshalling took " + new Double(Duration.between(between, done).toMillis()).doubleValue() / 1000
+                + "seconds");
+        if (result == null) {
+            throw RuntimeExceptionFactory.parseError(file);
+        }
+        return result;
+    }
+
+    public ITuple parseCppToM3AndAst(ISourceLocation file, IList stdLib, IList includeDirs, IMap additionalMacros,
+            IBool includeStdLib) {
+        this.includeStdLib = includeStdLib.getValue() || stdLib.isEmpty();
+        this.stdLib = stdLib;
+
+        IValue m3 = builder.M3_m3(file);
+        CDTParser parser = new CDTParser(stdLib, includeDirs, additionalMacros, includeStdLib.getValue(), vf, out, err);
+        IASTTranslationUnit tu = parser.parseFile(file);
+        IList comments = getCommentsFromTranslationUnit(tu);
+        ISet macroExpansions = getMacroExpansionsFromTranslationUnit(tu);
+        ISet macroDefinitions = getMacroDefinitionsFromTranslationUnit(tu);
+        ISet methodOverrides = getMethodOverrides(tu);
+
+        m3 = m3.asWithKeywordParameters().setParameter("comments", comments);
+        m3 = m3.asWithKeywordParameters().setParameter("macroExpansions", macroExpansions);
+        m3 = m3.asWithKeywordParameters().setParameter("macroDefinitions", macroDefinitions);
+        m3 = m3.asWithKeywordParameters().setParameter("methodOverrides", methodOverrides);
+        m3 = setM3IncludeInformationFromTranslationUnit(tu, m3);
+
+        declaredType = vf.setWriter();
+        IValue result = convertCdtToRascal(tu, true);
+        m3 = m3.asWithKeywordParameters().setParameter("declaredType", declaredType.done());
+
+        return vf.tuple(m3, result);
+    }
+
+    public ISet getMethodOverrides(IASTTranslationUnit tu) {
+        NameCollector anc = new NameCollector();
+        tu.accept(anc);
+        Set<IBinding> bindings = new HashSet<>();
+        Stream.of(anc.getNames()).forEach(it -> bindings.add(it.resolveBinding()));
+        ISetWriter methodOverrides = vf.setWriter();
+        bindings.stream().filter(ICPPMethod.class::isInstance).forEach(override -> {
+            Stream.of(ClassTypeHelper.findOverridden((ICPPMethod) override)).forEach(base -> {
+                try {
+                    methodOverrides.insert(vf.tuple(br.resolveBinding(base), br.resolveBinding(override)));
+                } catch (FactTypeUseException | URISyntaxException e) {
+                    err("Got FactTypeUseException\n" + e.getMessage());
+                }
+            });
+        });
+        return methodOverrides.done();
+    }
+
+    public ISet getMacroDefinitionsFromTranslationUnit(IASTTranslationUnit tu) {
+        return Stream.of(tu.getMacroDefinitions()).map(it -> {
+            try {
+                return vf.tuple(br.resolveBinding(it.getName().resolveBinding()), getSourceLocation(it));
+            } catch (URISyntaxException e) {
+                return vf.tuple(vf.sourceLocation(URIUtil.rootScheme("unknown")), getSourceLocation(it));
+            }
+        }).collect(vf.setWriter());
+    }
+
+    public IList getCommentsFromTranslationUnit(IASTTranslationUnit tu) {
+        return Stream.of(tu.getComments()).map(this::getSourceLocation).collect(vf.listWriter());
+    }
+
+    public IList parseForComments(ISourceLocation file, IList includePath, IMap additionalMacros) {
+        CDTParser parser = new CDTParser(vf.listWriter().done(), includePath, additionalMacros, true, vf, out, err);
+        IASTTranslationUnit tu = parser.parseFile(file);
+        return getCommentsFromTranslationUnit(tu);
+    }
+
+    public IValue setM3IncludeInformationFromTranslationUnit(IASTTranslationUnit tu, IValue m3) {
+        ISetWriter includeDirectives = vf.setWriter();
+        ISetWriter inactiveIncludes = vf.setWriter();
+        ISetWriter includeResolution = vf.setWriter();
+        Stream.of(tu.getIncludeDirectives()).forEach(it -> {
+            ISourceLocation include = vf.sourceLocation(URIUtil.rootScheme("unknown"));
+            try {
+                include = vf.sourceLocation(it.isSystemInclude() ? "cpp+systemInclude" : "cpp+include", null,
+                        it.getName().toString());
+            } catch (URISyntaxException e) {
+                // Shouldn't happen
+            }
+            if (it.isActive())
+                includeDirectives.insert(vf.tuple(include, getSourceLocation(it)));
+            else
+                inactiveIncludes.insert(vf.tuple(include, getSourceLocation(it)));
+            ISourceLocation path = "" == it.getPath() ? vf.sourceLocation(URIUtil.rootScheme("unresolved"))
+                    : vf.sourceLocation(it.getPath());
+            includeResolution.insert(vf.tuple(include, path));
+        });
+
+        m3 = m3.asWithKeywordParameters().setParameter("includeDirectives", includeDirectives.done());
+        m3 = m3.asWithKeywordParameters().setParameter("inactiveIncludes", inactiveIncludes.done());
+        m3 = m3.asWithKeywordParameters().setParameter("includeResolution", includeResolution.done());
+        return m3;
+    }
+
+    public ISet getMacroExpansionsFromTranslationUnit(IASTTranslationUnit tu) {
+        ISetWriter macros = vf.setWriter();
+        Stream.of(tu.getMacroExpansions()).forEach(it -> {
+            ISourceLocation decl;
+            try {
+                decl = br.resolveBinding(it.getMacroReference().resolveBinding());
+            } catch (URISyntaxException e) {
+                decl = vf.sourceLocation(URIUtil.rootScheme("unknown"));
+            }
+            macros.insert(vf.tuple(getSourceLocation(it), decl));
+        });
+        return macros.done();
+    }
+
+    private void addDeclaredType(ISourceLocation decl, IConstructor typ) {
+        if (toM3)
+            declaredType.insert(vf.tuple(decl, typ));
+    }
+
+    public ISet parseForMacros(ISourceLocation file, IList includePath, IMap additionalMacros) {
+        CDTParser parser = new CDTParser(vf.listWriter().done(), includePath, additionalMacros, true, vf, out, err);
+        IASTTranslationUnit tu = parser.parseFile(file);
+        return getMacroExpansionsFromTranslationUnit(tu);
+    }
+
+    public IValue parseString(IString code) throws CoreException {
+        return parseString(code, null);
+    }
+
+    public IValue parseString(IString code, ISourceLocation loc) throws CoreException {
+        stdLib = vf.listWriter().done();
+        FileContent fc = FileContent.create(loc == null ? "" : loc.toString(), code.getValue().toCharArray());
+        IScannerInfo si = new ScannerInfo();
+        IncludeFileContentProvider ifcp = IncludeFileContentProvider.getEmptyFilesProvider();
+        int options = ILanguage.OPTION_PARSE_INACTIVE_CODE;
+        IParserLogService log = new DefaultLogService();
+        IASTTranslationUnit tu = GPPLanguage.getDefault().getASTTranslationUnit(fc, si, ifcp, null, options, log);
+        return convertCdtToRascal(tu, false);
+    }
+
+    public IValue convertCdtToRascal(IASTTranslationUnit translationUnit, boolean toM3) {
+        this.toM3 = toM3;
+        translationUnit.accept(this);
+        if (stack.size() == 1)
+            return stack.pop();
+        if (stack.size() == 0)
+            throw new RuntimeException("Stack empty after converting, error");
+        IConstructor ast = stack.pop();
+        err("Superfluous nodes on the stack after converting:");
+        stack.iterator().forEachRemaining(it -> err(it.toString()));
+        return ast;
+    }
+
+    private int prefix = 0;
+
+    private String spaces() {
+        return StringUtils.repeat(" ", prefix);
+    }
+
+    private void out(String msg) {
+        out.println(spaces() + msg.replace("\n", "\n" + spaces()));
+    }
+
+    private void err(String msg) {
+        err.println(spaces() + msg.replace("\n", "\n" + spaces()));
+    }
+
+    public ISourceLocation getSourceLocation(IASTNode node) {
+        IASTFileLocation astFileLocation = node.getFileLocation();
+
+        if (astFileLocation != null) {
+            String fileName = astFileLocation.getFileName();
+            fileName = fileName.replace('\\', '/');
+            try {
+                return vf.sourceLocation(
+                        (ISourceLocation) new StandardTextReader().read(vf, new StringReader(fileName)),
+                        astFileLocation.getNodeOffset(), astFileLocation.getNodeLength());
+            } catch (FactParseError | FactTypeUseException | IOException e) {
+            }
+            if (!fileName.startsWith("/")) {
+                fileName = "/" + fileName;
+            }
+            try {
+                return vf.sourceLocation(
+                        (ISourceLocation) new StandardTextReader().read(vf, new StringReader(fileName)),
+                        astFileLocation.getNodeOffset(), astFileLocation.getNodeLength());
+            } catch (FactParseError | FactTypeUseException | IOException e) {
+            }
+            return vf.sourceLocation(vf.sourceLocation(fileName), astFileLocation.getNodeOffset(),
+                    astFileLocation.getNodeLength());
+        }
+        return vf.sourceLocation(URIUtil.assumeCorrect("unknown:///", "", ""));
+    }
+
+    public ISourceLocation getTokenSourceLocation(IASTNode node, String literal) {
+        ISourceLocation loc = getSourceLocation(node);
+        try {
+            IToken tokens = node.getSyntax();
+            while (tokens != null) {
+                if (literal.equals(tokens.getImage())) {
+                    return vf.sourceLocation(loc, loc.getOffset() + tokens.getOffset(), literal.length());
+                }
+                tokens = tokens.getNext();
+            }
+        } catch (ExpansionOverlapsBoundaryException e) {
+            // Fall back to node's source location. Possibly find string in node's image
+        }
+        return loc;
+    }
+
+    public boolean isMacroExpansion(IASTNode node) {
+        IASTNodeLocation[] nodeLocations = node.getNodeLocations();
+        return nodeLocations.length > 1
+                || nodeLocations.length == 1 && nodeLocations[0] instanceof IASTMacroExpansionLocation;
+    }
+
+    IList getAttributes(IASTAttributeOwner node) {
+        IListWriter attributeSpecifiers = vf.listWriter();
+        Stream.of(node.getAttributeSpecifiers()).forEach(it -> {
+            visit((IASTAttributeSpecifier) it);
+            attributeSpecifiers.append(stack.pop());
+        });
+        return attributeSpecifiers.done();
+    }
+
+    IList getModifiers(IASTNode node) {
+        boolean isMacroExpansion = isMacroExpansion(node);
+        IListWriter modifiers = vf.listWriter();
+
+        if (node instanceof ICPPASTDeclSpecifier) {
+            if (((ICPPASTDeclSpecifier) node).isFriend())
+                modifiers.append(builder.Modifier_friend(getTokenSourceLocation(node, "friend"), isMacroExpansion));
+            if (((ICPPASTDeclSpecifier) node).isVirtual())
+                modifiers.append(builder.Modifier_virtual(getTokenSourceLocation(node, "virtual"), isMacroExpansion));
+            if (((ICPPASTDeclSpecifier) node).isExplicit())
+                modifiers.append(builder.Modifier_explicit(getTokenSourceLocation(node, "explicit"), isMacroExpansion));
+            if (((ICPPASTDeclSpecifier) node).isConstexpr())
+                modifiers.append(
+                        builder.Modifier_constexpr(getTokenSourceLocation(node, "constexpr"), isMacroExpansion));
+            if (((ICPPASTDeclSpecifier) node).isThreadLocal())
+                modifiers.append(
+                        builder.Modifier_threadLocal(getTokenSourceLocation(node, "thread_local"), isMacroExpansion));
+        }
+
+        if (node instanceof ICPPASTFunctionDeclarator) {
+            if (((ICPPASTFunctionDeclarator) node).isMutable())
+                modifiers.append(builder.Modifier_mutable(getTokenSourceLocation(node, "mutable"), isMacroExpansion));
+            if (((ICPPASTFunctionDeclarator) node).isPureVirtual())
+                modifiers.append(
+                        builder.Modifier_pureVirtual(getTokenSourceLocation(node, "virtual"), isMacroExpansion));// check
+        }
+
+        if (node instanceof IASTDeclSpecifier) {
+            switch (((IASTDeclSpecifier) node).getStorageClass()) {
+            case IASTDeclSpecifier.sc_typedef:
+                modifiers.append(builder.Modifier_typedef(getTokenSourceLocation(node, "typedef"), isMacroExpansion));
+                break;
+            case IASTDeclSpecifier.sc_extern:
+                modifiers.append(builder.Modifier_extern(getTokenSourceLocation(node, "extern"), isMacroExpansion));
+                break;
+            case IASTDeclSpecifier.sc_static:
+                modifiers.append(builder.Modifier_static(getTokenSourceLocation(node, "static"), isMacroExpansion));
+                break;
+            case IASTDeclSpecifier.sc_auto:
+                modifiers.append(builder.Modifier_modAuto(getTokenSourceLocation(node, "auto"), isMacroExpansion));
+                break;
+            case IASTDeclSpecifier.sc_register:
+                modifiers.append(builder.Modifier_register(getTokenSourceLocation(node, "register"), isMacroExpansion));
+                break;
+            case IASTDeclSpecifier.sc_mutable:
+                modifiers.append(builder.Modifier_mutable(getTokenSourceLocation(node, "mutable"), isMacroExpansion));
+                break;
+            }
+        }
+
+        if (node instanceof IASTSimpleDeclSpecifier) {
+            if (((IASTSimpleDeclSpecifier) node).isSigned())
+                modifiers.append(builder.Modifier_signed(getTokenSourceLocation(node, "signed"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isUnsigned())
+                modifiers.append(builder.Modifier_unsigned(getTokenSourceLocation(node, "unsigned"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isShort())
+                modifiers.append(builder.Modifier_short(getTokenSourceLocation(node, "short"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isLong())
+                modifiers.append(builder.Modifier_long(getTokenSourceLocation(node, "long"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isLongLong())
+                modifiers
+                        .append(builder.Modifier_longlong(getTokenSourceLocation(node, "long long"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isComplex())
+                modifiers.append(builder.Modifier_complex(getTokenSourceLocation(node, "_Complex"), isMacroExpansion));
+            if (((IASTSimpleDeclSpecifier) node).isImaginary())
+                modifiers.append(
+                        builder.Modifier_imaginary(getTokenSourceLocation(node, "_Imaginary"), isMacroExpansion));
+        }
+
+        if (node instanceof ICASTArrayModifier) {
+            if (((ICASTArrayModifier) node).isConst())
+                modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
+            if (((ICASTArrayModifier) node).isVolatile())
+                modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
+            if (((ICASTArrayModifier) node).isRestrict())
+                modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
+        } else if (node instanceof ICPPASTFunctionDeclarator) {
+            if (((ICPPASTFunctionDeclarator) node).isConst())
+                modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
+            if (((ICPPASTFunctionDeclarator) node).isVolatile())
+                modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
+        } else if (node instanceof IASTDeclSpecifier) {
+            if (((IASTDeclSpecifier) node).isConst())
+                modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
+            if (((IASTDeclSpecifier) node).isVolatile())
+                modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
+            if (((IASTDeclSpecifier) node).isRestrict())
+                modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
+            if (((IASTDeclSpecifier) node).isInline())
+                modifiers.append(builder.Modifier_inline(getTokenSourceLocation(node, "inline"), isMacroExpansion));
+        } else if (node instanceof IASTPointer) {
+            if (((IASTPointer) node).isConst())
+                modifiers.append(builder.Modifier_const(getTokenSourceLocation(node, "const"), isMacroExpansion));
+            if (((IASTPointer) node).isVolatile())
+                modifiers.append(builder.Modifier_volatile(getTokenSourceLocation(node, "volatile"), isMacroExpansion));
+            if (((IASTPointer) node).isRestrict())
+                modifiers.append(builder.Modifier_restrict(getTokenSourceLocation(node, "restrict"), isMacroExpansion));
+        } else if (node instanceof ICPPASTNamespaceDefinition) {
+            if (((ICPPASTNamespaceDefinition) node).isInline())
+                modifiers.append(builder.Modifier_inline(getTokenSourceLocation(node, "inline"), isMacroExpansion));
+        }
+
+        if (node instanceof ICPPASTNamedTypeSpecifier) {
+            if (((ICPPASTNamedTypeSpecifier) node).isTypename())
+                modifiers.append(builder.Modifier_typename(getTokenSourceLocation(node, "typename"), isMacroExpansion));
+        } else if (node instanceof ICPPASTUsingDeclaration)
+            if (((ICPPASTUsingDeclaration) node).isTypename())
+                modifiers.append(builder.Modifier_typename(getTokenSourceLocation(node, "typename"), isMacroExpansion));
+
+        return modifiers.done().stream()
+                .sorted((v1, v2) -> ((ISourceLocation) v1.asWithKeywordParameters().getParameter("src")).getOffset()
+                        - ((ISourceLocation) v2.asWithKeywordParameters().getParameter("src")).getOffset())
+                .collect(vf.listWriter());
+    }
+
+    @Override
+    public int visit(IASTTranslationUnit tu) {
+        ISourceLocation loc = getSourceLocation(tu);
+        boolean isMacroExpansion = isMacroExpansion(tu);
+        IListWriter declarations = vf.listWriter();
+        declLoop: for (IASTDeclaration declaration : tu.getDeclarations()) {
+            if (monitor.jobIsCanceled("")) {
+                declarations.append(builder.Declaration_problemDeclaration(
+                        vf.sourceLocation(URIUtil.assumeCorrect("interrupted:///")), isMacroExpansion));
+                break;
+            }
+            ISourceLocation declLoc = getSourceLocation(declaration);
+            if (!includeStdLib) {
+                for (IValue it : stdLib) {
+                    ISourceLocation l = (ISourceLocation) it;
+                    if (l.getScheme().equals(declLoc.getScheme()) && declLoc.getPath().startsWith(l.getPath())) {
+                        continue declLoop;
+                    }
+                }
+            }
+            declaration.accept(this);
+            declarations.append(stack.pop());
+        }
+
+        IConstructor translationUnit = builder.Declaration_translationUnit(declarations.done(), loc, isMacroExpansion);
+        stack.push(translationUnit);
+        return PROCESS_ABORT;
+    }
+
+    // Names
+
+    @Override
+    public int visit(IASTName name) {
+        if (name instanceof IASTImplicitName)
+            visit((IASTImplicitName) name);
+        else if (name instanceof ICPPASTName)
+            visit((ICPPASTName) name);
+        else {
+            err("No sub-interfaced IASTName? " + name.getClass().getName() + ": " + name.getRawSignature());
+            throw new RuntimeException("NYI at " + getSourceLocation(name));
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTImplicitName name) {
+        err("IASTImplicitName " + name.getRawSignature());
+        boolean alternate = name.isAlternate();
+        boolean operator = name.isOperator();
+        IASTName _lastName = name.getLastName();
+        throw new RuntimeException("NYI at " + getSourceLocation(name));
+    }
+
+    public int visit(ICPPASTName name) {
+        ISourceLocation loc = getSourceLocation(name);
+        boolean isMacroExpansion = isMacroExpansion(name);
+        if (name instanceof ICPPASTConversionName)
+            visit((ICPPASTConversionName) name);
+        else if (name instanceof ICPPASTOperatorName)
+            visit((ICPPASTOperatorName) name);
+        else if (name instanceof ICPPASTQualifiedName)
+            visit((ICPPASTQualifiedName) name);
+        else if (name instanceof ICPPASTTemplateId)
+            visit((ICPPASTTemplateId) name);
+        else {
+            stack.push(builder.Name_name(new String(name.toCharArray()), loc, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTConversionName name) {
+        ISourceLocation loc = getSourceLocation(name);
+        boolean isMacroExpansion = isMacroExpansion(name);
+        IConstructor typ = tr.resolveType(name);
+        name.getTypeId().accept(this);
+        stack.push(builder.Name_conversionName(name.toString(), stack.pop(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTOperatorName name) {
+        ISourceLocation loc = getSourceLocation(name);
+        boolean isMacroExpansion = isMacroExpansion(name);
+        stack.push(builder.Name_operatorName(name.toString(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTQualifiedName name) {
+        ISourceLocation loc = getSourceLocation(name);
+        boolean isMacroExpansion = isMacroExpansion(name);
+        ISourceLocation decl = br.resolveBinding(name);
+
+        IListWriter qualifier = vf.listWriter();
+        Stream.of(name.getQualifier()).forEach(it -> {
+            it.accept(this);
+            qualifier.append(stack.pop());
+        });
+
+        name.getLastName().accept(this);
+        IConstructor lastName = stack.pop();
+        // TODO: check fullyQualified
+        if (name.isFullyQualified())
+            ;
+        // err("WARNING: ICPPASTQualifiedName has fullyQualified=true");
+        stack.push(builder.Name_qualifiedName(qualifier.done(), lastName, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTemplateId name) {
+        ISourceLocation loc = getSourceLocation(name);
+        boolean isMacroExpansion = isMacroExpansion(name);
+        ISourceLocation decl = br.resolveBinding(name);
+
+        name.getTemplateName().accept(this);
+        IConstructor templateName = stack.pop();
+        IListWriter templateArguments = vf.listWriter();
+        Stream.of(name.getTemplateArguments()).forEach(it -> {
+            it.accept(this);
+            templateArguments.append(stack.pop());
+        });
+        stack.push(builder.Name_templateId(templateName, templateArguments.done(), loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    // Declarations
+
+    @Override
+    public int visit(IASTDeclaration declaration) {
+        if (declaration instanceof IASTASMDeclaration)
+            visit((IASTASMDeclaration) declaration);
+        else if (declaration instanceof IASTFunctionDefinition)
+            visit((IASTFunctionDefinition) declaration);
+        else if (declaration instanceof IASTSimpleDeclaration)
+            visit((IASTSimpleDeclaration) declaration);
+        else if (declaration instanceof ICPPASTAliasDeclaration)
+            visit((ICPPASTAliasDeclaration) declaration);
+        else if (declaration instanceof ICPPASTExplicitTemplateInstantiation)
+            visit((ICPPASTExplicitTemplateInstantiation) declaration);
+        else if (declaration instanceof ICPPASTLinkageSpecification)
+            visit((ICPPASTLinkageSpecification) declaration);
+        else if (declaration instanceof ICPPASTNamespaceAlias)
+            visit((ICPPASTNamespaceAlias) declaration);
+        // In ASTVisitor interface, not needed?
+        // else if (declaration instanceof ICPPASTNamespaceDefinition)
+        // visit((ICPPASTNamespaceDefinition) declaration);
+        else if (declaration instanceof ICPPASTStaticAssertDeclaration)
+            visit((ICPPASTStaticAssertDeclaration) declaration);
+        else if (declaration instanceof ICPPASTTemplateSpecialization)
+            visit((ICPPASTTemplateSpecialization) declaration);
+        else if (declaration instanceof ICPPASTTemplateDeclaration)
+            visit((ICPPASTTemplateDeclaration) declaration);
+        else if (declaration instanceof ICPPASTUsingDeclaration)
+            visit((ICPPASTUsingDeclaration) declaration);
+        else if (declaration instanceof ICPPASTUsingDirective)
+            visit((ICPPASTUsingDirective) declaration);
+        else if (declaration instanceof ICPPASTVisibilityLabel)
+            visit((ICPPASTVisibilityLabel) declaration);
+        else if (declaration instanceof IASTProblemDeclaration)
+            // should not happen
+            visit((IASTProblemDeclaration) declaration);
+        else {
+            throw new RuntimeException("Declaration: encountered non-implemented subtype "
+                    + declaration.getClass().getName() + " at " + getSourceLocation(declaration));
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTAliasDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        ISourceLocation decl = br.resolveBinding(declaration);
+        IList attributes = getAttributes(declaration);
+
+        declaration.getAlias().accept(this);
+        IConstructor alias = stack.pop();
+        declaration.getMappingTypeId().accept(this);
+        IConstructor mappingTypeId = stack.pop();
+        stack.push(builder.Declaration_alias(alias, mappingTypeId, attributes, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTExplicitTemplateInstantiation declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        declaration.getDeclaration().accept(this);
+        switch (declaration.getModifier()) {
+        case 0:
+            stack.push(builder.Declaration_explicitTemplateInstantiation(stack.pop(), loc, isMacroExpansion));
+            break;
+        case ICPPASTExplicitTemplateInstantiation.STATIC:
+            stack.push(builder.Declaration_explicitTemplateInstantiation(
+                    builder.Modifier_static(getTokenSourceLocation(declaration, "static"), isMacroExpansion),
+                    stack.pop(), loc, isMacroExpansion));
+            break;
+        case ICPPASTExplicitTemplateInstantiation.INLINE:
+            stack.push(builder.Declaration_explicitTemplateInstantiation(
+                    builder.Modifier_inline(getTokenSourceLocation(declaration, "inline"), isMacroExpansion),
+                    stack.pop(), loc, isMacroExpansion));
+            break;
+        case ICPPASTExplicitTemplateInstantiation.EXTERN:
+            stack.push(builder.Declaration_explicitTemplateInstantiation(
+                    builder.Modifier_extern(getTokenSourceLocation(declaration, "extern"), isMacroExpansion),
+                    stack.pop(), loc, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("ICPPASTExplicitTemplateInstantiation encountered unknown modifier "
+                    + declaration.getModifier() + " at " + getSourceLocation(declaration));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTLinkageSpecification declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+
+        IListWriter declarations = vf.listWriter();
+        Stream.of(declaration.getDeclarations()).forEach(it -> {
+            it.accept(this);
+            declarations.append(stack.pop());
+        });
+        stack.push(builder.Declaration_linkageSpecification(declaration.getLiteral(), declarations.done(), loc,
+                isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTNamespaceAlias declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        ISourceLocation decl = br.resolveBinding(declaration);
+
+        declaration.getAlias().accept(this);
+        IConstructor alias = stack.pop();
+        declaration.getMappingName().accept(this);
+        IConstructor mappingName = stack.pop();
+        stack.push(builder.Declaration_namespaceAlias(alias, mappingName, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTStaticAssertDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        declaration.getCondition().accept(this);
+        IConstructor condition = stack.pop();
+        declaration.getMessage().accept(this);
+        stack.push(builder.Declaration_staticAssert(condition, stack.pop(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTemplateDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        IConstructor typ = tr.resolveType(declaration);
+        // The "export" keyword has been removed from the C++ standard
+        IListWriter templateParameters = vf.listWriter();
+        Stream.of(declaration.getTemplateParameters()).forEach(it -> {
+            it.accept(this);
+            templateParameters.append(stack.pop());
+        });
+        declaration.getDeclaration().accept(this);
+        stack.push(builder.Declaration_template(templateParameters.done(), stack.pop(), typ, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTemplateSpecialization declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        declaration.getDeclaration().accept(this);
+        stack.push(builder.Declaration_explicitTemplateSpecialization(stack.pop(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTUsingDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        ISourceLocation decl = br.resolveBinding(declaration);
+        IList attributes = getAttributes(declaration);
+        IList modifiers = getModifiers(declaration);
+        declaration.getName().accept(this);
+        stack.push(
+                builder.Declaration_usingDeclaration(modifiers, stack.pop(), attributes, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTUsingDirective declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        ISourceLocation decl = br.resolveBinding(declaration);
+        IList attributes = getAttributes(declaration);
+        IASTName qualifiedName = declaration.getQualifiedName();
+        qualifiedName.accept(this);
+        stack.push(builder.Declaration_usingDirective(stack.pop(), attributes, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTVisibilityLabel declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        switch (declaration.getVisibility()) {
+        case ICPPASTVisibilityLabel.v_public:
+            stack.push(builder.Declaration_visibilityLabel(
+                    builder.Modifier_public(getTokenSourceLocation(declaration, "public"), isMacroExpansion), loc,
+                    isMacroExpansion));
+            break;
+        case ICPPASTVisibilityLabel.v_protected:
+            stack.push(builder.Declaration_visibilityLabel(
+                    builder.Modifier_protected(getTokenSourceLocation(declaration, "protected"), isMacroExpansion), loc,
+                    isMacroExpansion));
+            break;
+        case ICPPASTVisibilityLabel.v_private:
+            stack.push(builder.Declaration_visibilityLabel(
+                    builder.Modifier_private(getTokenSourceLocation(declaration, "private"), isMacroExpansion), loc,
+                    isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("Unknown CPPVisibilityLabel code " + declaration.getVisibility() + " at "
+                    + getSourceLocation(declaration) + ". Exiting");
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTASMDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        stack.push(builder.Declaration_asmDeclaration(declaration.getAssembly(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTFunctionDefinition definition) {
+        ISourceLocation loc = getSourceLocation(definition);
+        boolean isMacroExpansion = isMacroExpansion(definition);
+        if (definition instanceof ICPPASTFunctionDefinition) {
+            IList attributes = getAttributes((ICPPASTFunctionDefinition) definition);
+            boolean isDefaulted = ((ICPPASTFunctionDefinition) definition).isDefaulted();
+            boolean isDeleted = ((ICPPASTFunctionDefinition) definition).isDeleted();
+
+            definition.getDeclSpecifier().accept(this);
+            IConstructor declSpecifier = stack.pop();
+            definition.getDeclarator().accept(this);
+            IConstructor declarator = stack.pop();
+
+            IListWriter memberInitializers = vf.listWriter();
+            Stream.of(((ICPPASTFunctionDefinition) definition).getMemberInitializers()).forEach(it -> {
+                it.accept(this);
+                memberInitializers.append(stack.pop());
+            });
+
+            if (isDefaulted && isDeleted)
+                err("WARNING: IASTFunctionDefinition both deleted and defaulted");
+            if ((isDefaulted || isDeleted) && definition instanceof ICPPASTFunctionWithTryBlock)
+                throw new RuntimeException("IASTFunctionDefinition defaulted/deleted and with try? at " + loc);
+            if (isDefaulted)
+                stack.push(builder.Declaration_defaultedFunctionDefinition(declSpecifier, memberInitializers.done(),
+                        declarator, attributes, loc, isMacroExpansion));
+            else if (isDeleted)
+                stack.push(builder.Declaration_deletedFunctionDefinition(declSpecifier, memberInitializers.done(),
+                        declarator, attributes, loc, isMacroExpansion));
+            else if (definition instanceof ICPPASTFunctionWithTryBlock) {
+                IListWriter catchHandlers = vf.listWriter();
+                Stream.of(((ICPPASTFunctionWithTryBlock) definition).getCatchHandlers()).forEach(it -> {
+                    it.accept(this);
+                    catchHandlers.append(stack.pop());
+                });
+                definition.getBody().accept(this);
+                stack.push(builder.Declaration_functionWithTryBlockDefinition(declSpecifier, declarator,
+                        memberInitializers.done(), stack.pop(), catchHandlers.done(), attributes, loc,
+                        isMacroExpansion));
+            } else {
+                definition.getBody().accept(this);
+                stack.push(builder.Declaration_functionDefinition(declSpecifier, declarator, memberInitializers.done(),
+                        stack.pop(), attributes, loc, isMacroExpansion));
+            }
+            addDeclaredType(br.resolveBinding(definition.getDeclarator()), tr.resolveType(definition.getDeclarator()));
+        } else { // C Function definition
+            throw new RuntimeException("Encountered C function definition at " + loc + ", NYI");
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTParameterDeclaration parameterDeclaration) {
+        ISourceLocation loc = getSourceLocation(parameterDeclaration);
+        boolean isMacroExpansion = isMacroExpansion(parameterDeclaration);
+        if (parameterDeclaration instanceof ICPPASTParameterDeclaration) {
+            // TODO: add isParameterPack()
+            ICPPASTParameterDeclaration declaration = (ICPPASTParameterDeclaration) parameterDeclaration;
+
+            declaration.getDeclSpecifier().accept(this);
+            IConstructor declSpecifier = stack.pop();
+            if (declaration.getDeclarator() == null)
+                stack.push(builder.Declaration_parameter(declSpecifier, loc, isMacroExpansion));
+            else {
+                declaration.getDeclarator().accept(this);
+                stack.push(builder.Declaration_parameter(declSpecifier, stack.pop(), loc, isMacroExpansion));
+            }
+        } else {
+            throw new RuntimeException("NYI: C ParameterDeclaration at " + loc);
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTProblemDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        IASTProblem problem = declaration.getProblem();
+        String raw = declaration.getRawSignature();
+        if (doProblemLogging) {
+            if (!(raw.contains("$fail$") || raw.contains("�") || raw.contains("__int64(24)")
+                    || raw.contains("CString default"))) {
+                err("ProblemDeclaration: ");
+                prefix += 4;
+                err(Integer.toHexString(problem.getID()) + ": " + problem.getMessageWithLocation() + ", " + loc);
+                err(raw);
+                prefix -= 4;
+            }
+        }
+        stack.push(builder.Declaration_problemDeclaration(loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTSimpleDeclaration declaration) {
+        ISourceLocation loc = getSourceLocation(declaration);
+        boolean isMacroExpansion = isMacroExpansion(declaration);
+        IList attributes = getAttributes(declaration);
+
+        declaration.getDeclSpecifier().accept(this);
+        IConstructor declSpecifier = stack.pop();
+
+        IListWriter declarators = vf.listWriter();
+        Stream.of(declaration.getDeclarators()).forEach(it -> {
+            it.accept(this);
+            declarators.append(stack.pop());
+            addDeclaredType(br.resolveBinding(it), tr.resolveType(it));
+        });
+        stack.push(builder.Declaration_simpleDeclaration(declSpecifier, declarators.done(), attributes, loc,
+                isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    // Initializers
+
+    @Override
+    public int visit(IASTInitializer initializer) {
+        if (initializer instanceof IASTEqualsInitializer)
+            visit((IASTEqualsInitializer) initializer);
+        else if (initializer instanceof IASTInitializerList)
+            visit((IASTInitializerList) initializer);
+        else if (initializer instanceof ICASTDesignatedInitializer)
+            visit((ICASTDesignatedInitializer) initializer);
+        else if (initializer instanceof ICPPASTConstructorChainInitializer)
+            visit((ICPPASTConstructorChainInitializer) initializer);
+        else if (initializer instanceof ICPPASTConstructorInitializer)
+            visit((ICPPASTConstructorInitializer) initializer);
+        else if (initializer instanceof ICPPASTDesignatedInitializer)
+            visit((ICPPASTDesignatedInitializer) initializer);
+        else {
+            throw new RuntimeException("Initializer: encountered unknown subtype "
+                    + initializer.getClass().getSimpleName() + " at " + getSourceLocation(initializer));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTEqualsInitializer initializer) {
+        ISourceLocation loc = getSourceLocation(initializer);
+        boolean isMacroExpansion = isMacroExpansion(initializer);
+        initializer.getInitializerClause().accept(this);
+        stack.push(builder.Expression_equalsInitializer(stack.pop(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTInitializerList initializer) {
+        // TODO: cpp: check isPackExpansion, maybe getSize
+        ISourceLocation loc = getSourceLocation(initializer);
+        boolean isMacroExpansion = isMacroExpansion(initializer);
+        IListWriter clauses = vf.listWriter();
+        Stream.of(initializer.getClauses()).forEach(it -> {
+            it.accept(this);
+            clauses.append(stack.pop());
+        });
+        stack.push(builder.Expression_initializerList(clauses.done(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICASTDesignatedInitializer initializer) {
+        err("ICASTDesignatedInitializer: " + initializer.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(initializer));
+    }
+
+    public int visit(ICPPASTConstructorChainInitializer initializer) {
+        // TODO: check isPackExpansion
+        ISourceLocation loc = getSourceLocation(initializer);
+        boolean isMacroExpansion = isMacroExpansion(initializer);
+        ISourceLocation decl = br.resolveBinding(initializer);
+
+        initializer.getMemberInitializerId().accept(this);
+        IConstructor memberInitializerId = stack.pop();
+        initializer.getInitializer().accept(this);
+        IConstructor memberInitializer = stack.pop();
+
+        stack.push(builder.Expression_constructorChainInitializer(memberInitializerId, memberInitializer, loc, decl,
+                isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTConstructorInitializer initializer) {
+        ISourceLocation loc = getSourceLocation(initializer);
+        boolean isMacroExpansion = isMacroExpansion(initializer);
+
+        IListWriter arguments = vf.listWriter();
+        Stream.of(initializer.getArguments()).forEach(it -> {
+            it.accept(this);
+            arguments.append(stack.pop());
+        });
+
+        stack.push(builder.Expression_constructorInitializer(arguments.done(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTDesignatedInitializer initializer) {
+        ISourceLocation loc = getSourceLocation(initializer);
+        boolean isMacroExpansion = isMacroExpansion(initializer);
+
+        IListWriter designators = vf.listWriter();
+        Stream.of(initializer.getDesignators()).forEach(it -> {
+            it.accept(this);
+            designators.append(stack.pop());
+        });
+
+        initializer.getOperand().accept(this);
+        stack.push(builder.Expression_designatedInitializer(designators.done(), stack.pop(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    // InitializerClauses
+
+    public int visit(IASTInitializerClause initializerClause) {
+        if (initializerClause instanceof IASTExpression)
+            visit((IASTExpression) initializerClause);
+        else if (initializerClause instanceof IASTInitializerList)
+            visit((IASTInitializerList) initializerClause);
+        else if (initializerClause instanceof ICASTDesignatedInitializer)
+            visit((ICASTDesignatedInitializer) initializerClause);
+        else if (initializerClause instanceof ICPPASTInitializerClause)
+            visit((ICPPASTInitializerClause) initializerClause);
+        else
+            throw new RuntimeException(
+                    "Unknown IASTInitializerClause subclass " + initializerClause.getClass().getName() + " at "
+                            + getSourceLocation(initializerClause) + ". Exiting");
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTInitializerClause initializer) {
+        err("ICPPASTInitializerClause: " + initializer.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(initializer));
+    }
+
+    // Declarators
+
+    @Override
+    public int visit(IASTDeclarator declarator) {
+        if (declarator instanceof IASTArrayDeclarator)
+            visit((IASTArrayDeclarator) declarator);
+        else if (declarator instanceof IASTFunctionDeclarator)
+            visit((IASTFunctionDeclarator) declarator);
+        else if (declarator instanceof ICPPASTDeclarator)
+            visit((ICPPASTDeclarator) declarator);
+        else {
+            throw new RuntimeException("Unknown IASTDeclarator subclass " + declarator.getClass().getName() + "at "
+                    + getSourceLocation(declarator));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTArrayDeclarator declarator) {
+        ISourceLocation loc = getSourceLocation(declarator);
+        boolean isMacroExpansion = isMacroExpansion(declarator);
+        ISourceLocation decl = br.resolveBinding(declarator);
+        IList attributes = getAttributes(declarator);
+
+        IListWriter arrayModifiers = vf.listWriter();
+        Stream.of(declarator.getArrayModifiers()).forEach(it -> {
+            it.accept(this);
+            arrayModifiers.append(stack.pop());
+        });
+
+        IListWriter pointerOperators = vf.listWriter();
+        Stream.of(declarator.getPointerOperators()).forEach(it -> {
+            it.accept(this);
+            pointerOperators.append(stack.pop());
+        });
+
+        declarator.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        // TODO: check declaresParameterPack
+        if (declarator instanceof ICPPASTArrayDeclarator
+                && ((ICPPASTArrayDeclarator) declarator).declaresParameterPack())
+            out("WARNING: IASTArrayDeclarator has declaresParameterPack=true");
+
+        if (declarator.getNestedDeclarator() == null) {
+            if (declarator.getInitializer() == null)
+                stack.push(builder.Declarator_arrayDeclarator(pointerOperators.done(), name, arrayModifiers.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            else {
+                declarator.getInitializer().accept(this);
+                stack.push(builder.Declarator_arrayDeclarator(pointerOperators.done(), name, arrayModifiers.done(),
+                        stack.pop(), attributes, loc, decl, isMacroExpansion));
+            }
+        } else {
+            declarator.getNestedDeclarator().accept(this);
+            IConstructor nestedDeclarator = stack.pop();
+            if (declarator.getInitializer() == null)
+                stack.push(builder.Declarator_arrayDeclaratorNested(pointerOperators.done(), nestedDeclarator,
+                        arrayModifiers.done(), attributes, loc, decl, isMacroExpansion));
+            else {
+                declarator.getInitializer().accept(this);
+                stack.push(builder.Declarator_arrayDeclaratorNested(pointerOperators.done(), nestedDeclarator,
+                        arrayModifiers.done(), stack.pop(), attributes, loc, decl, isMacroExpansion));
+            }
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTFieldDeclarator declarator) {
+        err("FieldDeclarator: " + declarator.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declarator));
+    }
+
+    public int visit(IASTFunctionDeclarator declarator) {
+        if (declarator instanceof IASTStandardFunctionDeclarator)
+            visit((IASTStandardFunctionDeclarator) declarator);
+        else if (declarator instanceof ICASTKnRFunctionDeclarator)
+            visit((ICASTKnRFunctionDeclarator) declarator);
+        else
+            throw new RuntimeException("Unknown FunctionDeclarator subtype " + declarator.getClass().getName() + " at "
+                    + getSourceLocation(declarator) + ". Exiting");
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTStandardFunctionDeclarator declarator) {
+        if (declarator instanceof ICPPASTFunctionDeclarator)
+            visit((ICPPASTFunctionDeclarator) declarator);
+        else {
+            throw new RuntimeException("Unknown StandardFunctionDeclarator subtype " + declarator.getClass().getName()
+                    + " at " + getSourceLocation(declarator) + ". Exiting");
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICASTKnRFunctionDeclarator declarator) {
+        err("CKnRFunctionDeclarator: " + declarator.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declarator));
+    }
+
+    public int visit(ICPPASTDeclarator declarator) {
+        if (declarator instanceof ICPPASTArrayDeclarator)
+            visit((ICPPASTArrayDeclarator) declarator);
+        else if (declarator instanceof ICPPASTFieldDeclarator)
+            visit((ICPPASTFieldDeclarator) declarator);
+        else if (declarator instanceof ICPPASTFunctionDeclarator)
+            visit((ICPPASTFunctionDeclarator) declarator);
+        else {
+            ISourceLocation loc = getSourceLocation(declarator);
+            boolean isMacroExpansion = isMacroExpansion(declarator);
+            ISourceLocation decl = br.resolveBinding(declarator);
+            IList attributes = getAttributes(declarator);
+
+            // if (declarator.getNestedDeclarator() != null)
+            // err("WARNING: ICPPASTDeclarator has nestedDeclarator " +
+            // _nestedDeclarator.getRawSignature());
+
+            declarator.getName().accept(this);
+            IConstructor name = stack.pop();
+
+            IListWriter pointerOperators = vf.listWriter();
+            Stream.of(declarator.getPointerOperators()).forEach(it -> {
+                it.accept(this);
+                pointerOperators.append(stack.pop());
+            });
+
+            IASTInitializer initializer = declarator.getInitializer();
+            if (initializer == null) {
+                stack.push(builder.Declarator_declarator(pointerOperators.done(), name, attributes, loc, decl,
+                        isMacroExpansion));
+            } else {
+                initializer.accept(this);
+                stack.push(builder.Declarator_declarator(pointerOperators.done(), name, stack.pop(), attributes, loc,
+                        decl, isMacroExpansion));
+            }
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTArrayDeclarator declarator) {
+        visit((IASTArrayDeclarator) declarator);
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTFieldDeclarator declarator) {
+        ISourceLocation loc = getSourceLocation(declarator);
+        boolean isMacroExpansion = isMacroExpansion(declarator);
+        ISourceLocation decl = br.resolveBinding(declarator);
+        IList attributes = getAttributes(declarator);
+
+        IListWriter pointerOperators = vf.listWriter();
+        Stream.of(declarator.getPointerOperators()).forEach(it -> {
+            it.accept(this);
+            pointerOperators.append(stack.pop());
+        });
+
+        declarator.getBitFieldSize().accept(this);
+        IConstructor bitFieldSize = stack.pop();
+        declarator.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        IASTDeclarator nestedDeclarator = declarator.getNestedDeclarator();
+        if (nestedDeclarator != null)
+            err("WARNING: ICPPASTDeclarator has nestedDeclarator " + nestedDeclarator.getRawSignature());
+
+        IASTInitializer initializer = declarator.getInitializer();
+        if (initializer == null) {
+            stack.push(builder.Declarator_fieldDeclarator(pointerOperators.done(), name, bitFieldSize, attributes, loc,
+                    decl, isMacroExpansion));
+        } else {
+            initializer.accept(this);
+            stack.push(builder.Declarator_fieldDeclarator(pointerOperators.done(), name, bitFieldSize, stack.pop(),
+                    attributes, loc, decl, isMacroExpansion));
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTFunctionDeclarator declarator) {
+        // TODO: check refQualifier and declaresParameterPack
+        ISourceLocation loc = getSourceLocation(declarator);
+        boolean isMacroExpansion = isMacroExpansion(declarator);
+        ISourceLocation decl = br.resolveBinding(declarator);
+        // IConstructor typ = tr.resolveType(declarator);
+        IList attributes = getAttributes(declarator);
+        IList modifiers = getModifiers(declarator);
+
+        IASTDeclarator _nestedDeclarator = declarator.getNestedDeclarator();
+        IASTInitializer _initializer = declarator.getInitializer();
+        IASTTypeId _trailingReturnType = declarator.getTrailingReturnType();
+        IASTTypeId[] _exceptionSpecification = declarator.getExceptionSpecification();
+        ICPPASTExpression _noexceptExpression = declarator.getNoexceptExpression();
+
+        // TODO: fix when name == null
+        IConstructor name = builder.Name_name("", vf.sourceLocation(loc, loc.getOffset(), 0), isMacroExpansion);
+        IASTName _name = declarator.getName();
+        if (_name != null) {
+            _name.accept(this);
+            name = stack.pop();
+        }
+
+        IListWriter parameters = vf.listWriter();
+        Stream.of(declarator.getParameters()).forEach(it -> {
+            it.accept(this);
+            parameters.append(stack.pop());
+        });
+        if (declarator.takesVarArgs())
+            parameters.append(builder.Declaration_varArgs(getTokenSourceLocation(declarator, "..."), isMacroExpansion));
+
+        IListWriter virtSpecifiers = vf.listWriter();
+        Stream.of(declarator.getVirtSpecifiers()).forEach(it -> {
+            it.accept(this);
+            virtSpecifiers.append(stack.pop());
+        });
+
+        IListWriter pointerOperators = vf.listWriter();
+        Stream.of(declarator.getPointerOperators()).forEach(it -> {
+            it.accept(this);
+            pointerOperators.append(stack.pop());
+        });
+
+        if (_nestedDeclarator != null) {
+            if (_trailingReturnType != null)
+                throw new RuntimeException("FunctionDeclarator: Trailing return type and nested declarator? at " + loc);
+            _nestedDeclarator.accept(this);
+            IConstructor nestedDeclarator = stack.pop();
+            if (_initializer == null)
+                stack.push(builder.Declarator_functionDeclaratorNested(pointerOperators.done(), modifiers,
+                        nestedDeclarator, parameters.done(), virtSpecifiers.done(), attributes, loc, decl,
+                        isMacroExpansion));
+            else {
+                _initializer.accept(this);
+                stack.push(builder.Declarator_functionDeclaratorNested(pointerOperators.done(), modifiers,
+                        nestedDeclarator, parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl,
+                        isMacroExpansion));
+            }
+            // if
+            // (!(_exceptionSpecification.equals(ICPPASTFunctionDeclarator.NO_EXCEPTION_SPECIFICATION)))
+            // err("WARNING: ICPPASTFunctionDeclaration had nestedDeclarator and
+            // also exceptionSpecification");
+        } else if (_exceptionSpecification.equals(ICPPASTFunctionDeclarator.NO_EXCEPTION_SPECIFICATION)) {
+            if (_trailingReturnType == null)
+                stack.push(builder.Declarator_functionDeclarator(pointerOperators.done(), modifiers, name,
+                        parameters.done(), virtSpecifiers.done(), attributes, loc, decl, isMacroExpansion));
+            else {
+                _trailingReturnType.accept(this);
+                stack.push(builder.Declarator_functionDeclarator(pointerOperators.done(), modifiers, name,
+                        parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl,
+                        isMacroExpansion));
+            }
+        } else if (_exceptionSpecification.equals(IASTTypeId.EMPTY_TYPEID_ARRAY)) {
+            if (_trailingReturnType != null)
+                throw new RuntimeException(
+                        "FunctionDeclarator: Trailing return type and exception specification? at " + loc);
+            stack.push(builder.Declarator_functionDeclaratorWithES(pointerOperators.done(), modifiers, name,
+                    parameters.done(), virtSpecifiers.done(), attributes, loc, decl, isMacroExpansion));
+        } else if (_noexceptExpression != null) {
+            if (_trailingReturnType != null)
+                throw new RuntimeException(
+                        "FunctionDeclarator: Trailing return type and noexceptExpression? at " + loc);
+            if (_initializer != null)
+                throw new RuntimeException("FunctionDeclarator: Initializer and noexceptExpression? at " + loc);
+            _noexceptExpression.accept(this);
+            stack.push(builder.Declarator_functionDeclaratorNoexcept(pointerOperators.done(), modifiers, name,
+                    parameters.done(), virtSpecifiers.done(), stack.pop(), attributes, loc, decl, isMacroExpansion));
+        } else {
+            if (_trailingReturnType != null)
+                throw new RuntimeException(
+                        "FunctionDeclarator: Trailing return type and exception specification? at " + loc);
+            IListWriter exceptionSpecification = vf.listWriter();
+            Stream.of(_exceptionSpecification).forEach(it -> {
+                it.accept(this);
+                exceptionSpecification.append(stack.pop());
+            });
+            stack.push(builder.Declarator_functionDeclaratorWithES(pointerOperators.done(), modifiers, name,
+                    parameters.done(), virtSpecifiers.done(), exceptionSpecification.done(), attributes, loc, decl,
+                    isMacroExpansion));
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    // DeclSpecifiers
+
+    @Override
+    public int visit(IASTDeclSpecifier declSpec) {
+        if (declSpec instanceof IASTCompositeTypeSpecifier)
+            visit((IASTCompositeTypeSpecifier) declSpec);
+        else if (declSpec instanceof IASTElaboratedTypeSpecifier)
+            visit((IASTElaboratedTypeSpecifier) declSpec);
+        else if (declSpec instanceof IASTEnumerationSpecifier)
+            visit((IASTEnumerationSpecifier) declSpec);
+        else if (declSpec instanceof IASTNamedTypeSpecifier)
+            visit((IASTNamedTypeSpecifier) declSpec);
+        else if (declSpec instanceof IASTSimpleDeclSpecifier)
+            visit((IASTSimpleDeclSpecifier) declSpec);
+        else if (declSpec instanceof ICASTDeclSpecifier)
+            visit((ICASTDeclSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTDeclSpecifier)
+            visit((ICPPASTDeclSpecifier) declSpec);
+        else
+            throw new RuntimeException("Unknown sub-class encountered: " + declSpec.getClass().getName() + " at "
+                    + getSourceLocation(declSpec) + ". Exiting");
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTCompositeTypeSpecifier declSpec) {
+        if (declSpec instanceof ICASTCompositeTypeSpecifier)
+            visit((ICASTCompositeTypeSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTCompositeTypeSpecifier)
+            visit((ICPPASTCompositeTypeSpecifier) declSpec);
+        else
+            throw new RuntimeException("Unknown IASTCompositeTypeSpecifier subinterface "
+                    + declSpec.getClass().getName() + " at " + getSourceLocation(declSpec));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICASTCompositeTypeSpecifier declSpec) {
+        throw new RuntimeException("C-style CompositeTypeSpecifier encountered at " + getSourceLocation(declSpec));
+    }
+
+    public int visit(ICPPASTCompositeTypeSpecifier declSpec) {
+        ISourceLocation loc = getSourceLocation(declSpec);
+        boolean isMacroExpansion = isMacroExpansion(declSpec);
+        ISourceLocation decl = br.resolveBinding(declSpec);
+        IConstructor typ = tr.resolveType(declSpec);
+        IList attributes = getAttributes(declSpec);
+        IList modifiers = getModifiers(declSpec);
+
+        ICPPASTClassVirtSpecifier virtSpecifier = declSpec.getVirtSpecifier();
+        if (virtSpecifier != null && !(virtSpecifier.getKind().equals(ICPPASTClassVirtSpecifier.SpecifierKind.Final)))
+            throw new RuntimeException(
+                    "ICPPASTCompositeTypeSpecifier encountered unknown classVirtSpecifier type at " + loc);
+
+        declSpec.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        IListWriter members = vf.listWriter();
+        Stream.of(declSpec.getMembers()).forEach(it -> {
+            it.accept(this);
+            members.append(stack.pop());
+        });
+
+        IListWriter baseSpecifiers = vf.listWriter();
+        Stream.of(declSpec.getBaseSpecifiers()).forEach(it -> {
+            it.accept(this);
+            baseSpecifiers.append(stack.pop());
+        });
+
+        switch (declSpec.getKey()) {
+        case ICPPASTCompositeTypeSpecifier.k_struct:
+            if (virtSpecifier == null)
+                stack.push(builder.DeclSpecifier_struct(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            else
+                stack.push(builder.DeclSpecifier_structFinal(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            break;
+        case ICPPASTCompositeTypeSpecifier.k_union:
+            if (virtSpecifier == null)
+                stack.push(builder.DeclSpecifier_union(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            else
+                stack.push(builder.DeclSpecifier_unionFinal(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            break;
+        case ICPPASTCompositeTypeSpecifier.k_class:
+            if (virtSpecifier == null)
+                stack.push(builder.DeclSpecifier_class(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            else
+                stack.push(builder.DeclSpecifier_classFinal(modifiers, name, baseSpecifiers.done(), members.done(),
+                        attributes, loc, decl, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Unknown IASTCompositeTypeSpecifier code " + declSpec.getKey() + "at" + loc + ". Exiting");
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTElaboratedTypeSpecifier declSpec) {
+        ISourceLocation loc = getSourceLocation(declSpec);
+        if (declSpec instanceof ICPPASTElaboratedTypeSpecifier) {
+            boolean isMacroExpansion = isMacroExpansion(declSpec);
+            ISourceLocation decl = br.resolveBinding(declSpec);
+            IList modifiers = getModifiers(declSpec);
+
+            declSpec.getName().accept(this);
+            switch (declSpec.getKind()) {
+            case ICPPASTElaboratedTypeSpecifier.k_enum:
+                stack.push(builder.DeclSpecifier_etsEnum(modifiers, stack.pop(), loc, decl, isMacroExpansion));
+                break;
+            case ICPPASTElaboratedTypeSpecifier.k_struct:
+                stack.push(builder.DeclSpecifier_etsStruct(modifiers, stack.pop(), loc, decl, isMacroExpansion));
+                break;
+            case ICPPASTElaboratedTypeSpecifier.k_union:
+                stack.push(builder.DeclSpecifier_etsUnion(modifiers, stack.pop(), loc, decl, isMacroExpansion));
+                break;
+            case ICPPASTElaboratedTypeSpecifier.k_class:
+                stack.push(builder.DeclSpecifier_etsClass(modifiers, stack.pop(), loc, decl, isMacroExpansion));
+                break;
+            default:
+                throw new RuntimeException(
+                        "IASTElaboratedTypeSpecifier encountered unknown kind " + declSpec.getKind() + " at " + loc);
+            }
+        } else {
+            throw new RuntimeException("Unknown IASTElaboratedTypeSpecifier subclass "
+                    + declSpec.getClass().getSimpleName() + " at " + loc);
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTEnumerationSpecifier declSpec) {
+        if (declSpec instanceof ICPPASTEnumerationSpecifier)
+            visit((ICPPASTEnumerationSpecifier) declSpec);
+        else
+            throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTNamedTypeSpecifier declSpec) {
+        ISourceLocation loc = getSourceLocation(declSpec);
+        boolean isMacroExpansion = isMacroExpansion(declSpec);
+        ISourceLocation decl = br.resolveBinding(declSpec);
+        IList modifiers = getModifiers(declSpec);
+        declSpec.getName().accept(this);
+        stack.push(builder.DeclSpecifier_namedTypeSpecifier(modifiers, stack.pop(), loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTSimpleDeclSpecifier declSpec) {
+        if (declSpec instanceof ICPPASTSimpleDeclSpecifier) {
+            visit((ICPPASTSimpleDeclSpecifier) declSpec);
+            return PROCESS_ABORT;
+        }
+        throw new RuntimeException("NYI: C SimpleDeclSpecifier");
+    }
+
+    public int visit(ICASTDeclSpecifier declSpec) {
+        out("CDeclSpecifier: " + declSpec.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+    }
+
+    public int visit(ICPPASTDeclSpecifier declSpec) {
+        if (declSpec instanceof ICPPASTCompositeTypeSpecifier)
+            visit((ICPPASTCompositeTypeSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTElaboratedTypeSpecifier)
+            visit((ICPPASTElaboratedTypeSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTEnumerationSpecifier)
+            visit((ICPPASTEnumerationSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTNamedTypeSpecifier)
+            visit((ICPPASTNamedTypeSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTSimpleDeclSpecifier)
+            visit((ICPPASTSimpleDeclSpecifier) declSpec);
+        else if (declSpec instanceof ICPPASTTypeTransformationSpecifier)
+            visit((ICPPASTTypeTransformationSpecifier) declSpec);
+        else {
+            throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTElaboratedTypeSpecifier declSpec) {
+        out("CPPElaboratedTypeSpecifier: " + declSpec.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+    }
+
+    public int visit(ICPPASTEnumerationSpecifier declSpec) {
+        ISourceLocation loc = getSourceLocation(declSpec);
+        boolean isMacroExpansion = isMacroExpansion(declSpec);
+        ISourceLocation decl = br.resolveBinding(declSpec);
+        IConstructor typ = tr.resolveType(declSpec);
+        IList attributes = getAttributes(declSpec);
+        IList modifiers = getModifiers(declSpec);
+
+        declSpec.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        IListWriter enumerators = vf.listWriter();
+        Stream.of(declSpec.getEnumerators()).forEach(it -> {
+            it.accept(this);
+            enumerators.append(stack.pop());
+        });
+
+        IASTDeclSpecifier baseType = declSpec.getBaseType();
+        if (baseType == null) {
+            if (declSpec.isScoped()) {
+                if (declSpec.isOpaque())
+                    stack.push(builder.DeclSpecifier_enumScopedOpaque(modifiers, name, attributes, loc, decl,
+                            isMacroExpansion));
+                else
+                    stack.push(builder.DeclSpecifier_enumScoped(modifiers, name, enumerators.done(), attributes, loc,
+                            decl, isMacroExpansion));
+            } else
+                stack.push(builder.DeclSpecifier_enum(modifiers, name, enumerators.done(), attributes, loc, decl,
+                        isMacroExpansion));
+        } else {
+            baseType.accept(this);
+            if (declSpec.isScoped()) {
+                if (declSpec.isOpaque())
+                    stack.push(builder.DeclSpecifier_enumScopedOpaque(modifiers, stack.pop(), name, attributes, loc,
+                            decl, isMacroExpansion));
+                else
+                    stack.push(builder.DeclSpecifier_enumScoped(modifiers, stack.pop(), name, enumerators.done(),
+                            attributes, loc, decl, isMacroExpansion));
+            } else {
+                if (declSpec.isOpaque())
+                    stack.push(builder.DeclSpecifier_enumOpaque(modifiers, stack.pop(), name, attributes, loc, decl,
+                            isMacroExpansion));
+                else
+                    stack.push(builder.DeclSpecifier_enum(modifiers, stack.pop(), name, enumerators.done(), attributes,
+                            loc, decl, isMacroExpansion));
+            }
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTNamedTypeSpecifier declSpec) {
+        out("CPPNamedTypeSpecifier: " + declSpec.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+    }
+
+    public int visit(ICPPASTSimpleDeclSpecifier declSpec) {
+        ISourceLocation loc = getSourceLocation(declSpec);
+        boolean isMacroExpansion = isMacroExpansion(declSpec);
+        IConstructor typ = tr.resolveType(declSpec);
+        IList attributes = getAttributes(declSpec);
+        IList modifiers = getModifiers(declSpec);
+
+        switch (declSpec.getType()) {
+        case IASTSimpleDeclSpecifier.t_unspecified: {
+            ISourceLocation location = null;
+            if (modifiers.isEmpty()) {
+                location = vf.sourceLocation(loc, loc.getOffset(), 0);
+            } else {
+                ISourceLocation before = (ISourceLocation) modifiers.get(modifiers.size() - 1).asWithKeywordParameters()
+                        .getParameter("src");
+                location = vf.sourceLocation(before, before.getOffset() + before.getLength(), 0);
+            }
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_unspecified(location, isMacroExpansion), attributes, loc, isMacroExpansion));
+            break;
+        }
+        case IASTSimpleDeclSpecifier.t_void:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_void(getTokenSourceLocation(declSpec, "void"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_char:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_char(getTokenSourceLocation(declSpec, "char"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_int:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_integer(getTokenSourceLocation(declSpec, "int"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_float:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_float(getTokenSourceLocation(declSpec, "float"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_double:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_double(getTokenSourceLocation(declSpec, "double"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_bool:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_bool(getTokenSourceLocation(declSpec, "bool"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_wchar_t:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_wchar_t(getTokenSourceLocation(declSpec, "wchar_t"), isMacroExpansion), attributes,
+                    loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_typeof:
+            declSpec.getDeclTypeExpression().accept(this);
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_typeof(getTokenSourceLocation(declSpec, "typeof"), isMacroExpansion), stack.pop(),
+                    attributes, loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_decltype:
+            declSpec.getDeclTypeExpression().accept(this);
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_decltype(getTokenSourceLocation(declSpec, "decltype"), isMacroExpansion), stack.pop(),
+                    attributes, loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_auto:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_auto(getTokenSourceLocation(declSpec, "auto"), isMacroExpansion), attributes, loc,
+                    isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_char16_t:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_char16_t(getTokenSourceLocation(declSpec, "char16_t"), isMacroExpansion), attributes,
+                    loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_char32_t:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_char32_t(getTokenSourceLocation(declSpec, "char32_t"), isMacroExpansion), attributes,
+                    loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_int128:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_int128(getTokenSourceLocation(declSpec, "__int128"), isMacroExpansion), attributes,
+                    loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_float128:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_float128(getTokenSourceLocation(declSpec, "__float128"), isMacroExpansion), attributes,
+                    loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_decimal32:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_decimal128(getTokenSourceLocation(declSpec, "_Decimal32"), isMacroExpansion),
+                    attributes, loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_decimal64:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_decimal64(getTokenSourceLocation(declSpec, "_Decimal64"), isMacroExpansion),
+                    attributes, loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_decimal128:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers,
+                    builder.Type_decimal128(getTokenSourceLocation(declSpec, "_Decimal128"), isMacroExpansion),
+                    attributes, loc, isMacroExpansion));
+            break;
+        case IASTSimpleDeclSpecifier.t_decltype_auto:
+            stack.push(builder.DeclSpecifier_declSpecifier(modifiers, builder.Type_declTypeAuto(loc, isMacroExpansion),
+                    attributes, loc, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Unknown IASTSimpleDeclSpecifier kind " + declSpec.getType() + " at " + loc + ". Exiting");
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTypeTransformationSpecifier declSpec) {
+        // TODO: implement, check operator and operand
+        err("ICPPASTTypeTransformationSpecifier: " + declSpec.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(declSpec));
+    }
+
+    @Override
+    public int visit(IASTArrayModifier arrayModifier) {
+        if (arrayModifier instanceof ICASTArrayModifier)
+            throw new RuntimeException("NYI at " + getSourceLocation(arrayModifier));
+        ISourceLocation loc = getSourceLocation(arrayModifier);
+        boolean isMacroExpansion = isMacroExpansion(arrayModifier);
+        IList attributes = getAttributes(arrayModifier);
+
+        IASTExpression constantExpression = arrayModifier.getConstantExpression();
+        if (constantExpression == null)
+            stack.push(builder.Expression_arrayModifier(attributes, loc, isMacroExpansion));
+        else {
+            constantExpression.accept(this);
+            stack.push(builder.Expression_arrayModifier(stack.pop(), attributes, loc, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTPointerOperator ptrOperator) {
+        if (ptrOperator instanceof IASTPointer)
+            visit((IASTPointer) ptrOperator);
+        else if (ptrOperator instanceof ICPPASTReferenceOperator)
+            visit((ICPPASTReferenceOperator) ptrOperator);
+        else
+            throw new RuntimeException("Unknown IASTPointerOperator subtype +" + ptrOperator.getClass().getName()
+                    + " at " + getSourceLocation(ptrOperator) + ". Exiting");
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTPointer pointer) {
+        ISourceLocation loc = getSourceLocation(pointer);
+        boolean isMacroExpansion = isMacroExpansion(pointer);
+        IList attributes = getAttributes(pointer);
+        IList modifiers = getModifiers(pointer);
+        if (pointer instanceof ICPPASTPointerToMember) {
+            ISourceLocation decl = br.resolveBinding(((ICPPASTPointerToMember) pointer));
+            ((ICPPASTPointerToMember) pointer).getName().accept(this);
+            stack.push(builder.Declaration_pointerToMember(modifiers, stack.pop(), attributes, loc, decl,
+                    isMacroExpansion));
+        } else
+            stack.push(builder.Declaration_pointer(modifiers, attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTReferenceOperator referenceOperator) {
+        ISourceLocation loc = getSourceLocation(referenceOperator);
+        boolean isMacroExpansion = isMacroExpansion(referenceOperator);
+        IList attributes = getAttributes(referenceOperator);
+        if (referenceOperator.isRValueReference())
+            stack.push(builder.Declaration_rvalueReference(attributes, loc, isMacroExpansion));
+        else
+            stack.push(builder.Declaration_reference(attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTAttribute attribute) {
+        ISourceLocation src = getSourceLocation(attribute);
+        if (attribute.getArgumentClause() == null || attribute.getArgumentClause().getTokenCharImage() == null)
+            stack.push(builder.Attribute_attribute(new String(attribute.getName()), src));
+        else
+            stack.push(builder.Attribute_attribute(new String(attribute.getName()),
+                    new String(attribute.getArgumentClause().getTokenCharImage()), src));
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTAttributeSpecifier specifier) {
+        ISourceLocation src = getSourceLocation(specifier);
+        if (specifier instanceof ICPPASTAlignmentSpecifier) {
+            IASTExpression expression = ((ICPPASTAlignmentSpecifier) specifier).getExpression();
+            if (expression != null)
+                expression.accept(this);
+            else
+                ((ICPPASTAlignmentSpecifier) specifier).getTypeId().accept(this);
+            stack.push(builder.Attribute_alignmentSpecifier(stack.pop(), src));
+        } else if (specifier instanceof IASTAttributeList) {
+            IASTAttributeList list = (IASTAttributeList) specifier;
+            IListWriter attributes = vf.listWriter();
+            Stream.of(list.getAttributes()).forEach(it -> {
+                it.accept(this);
+                attributes.append(stack.pop());
+            });
+            if (specifier instanceof IMSASTDeclspecList)
+                stack.push(builder.Attribute_msDeclspecList(attributes.done(), src));
+            else if (specifier instanceof IGCCASTAttributeList)
+                stack.push(builder.Attribute_gccAttributeList(attributes.done(), src));
+            else
+                stack.push(builder.Attribute_attributeSpecifier(attributes.done(), src));
+        } else {
+            throw new RuntimeException(
+                    "Unknown AttributeSpecifier type: " + specifier.getClass().getSimpleName() + " at " + src);
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTToken token) {
+        err("Token: " + new String(token.getTokenCharImage()));
+        throw new RuntimeException("NYI at " + getSourceLocation(token));
+    }
+
+    @Override
+    public int visit(IASTExpression expression) {
+        if (expression instanceof IASTArraySubscriptExpression)
+            visit((IASTArraySubscriptExpression) expression);
+        else if (expression instanceof IASTBinaryExpression)
+            visit((IASTBinaryExpression) expression);
+        else if (expression instanceof IASTBinaryTypeIdExpression)
+            visit((IASTBinaryTypeIdExpression) expression);
+        else if (expression instanceof IASTCastExpression)
+            visit((IASTCastExpression) expression);
+        else if (expression instanceof IASTConditionalExpression)
+            visit((IASTConditionalExpression) expression);
+        else if (expression instanceof IASTExpressionList)
+            visit((IASTExpressionList) expression);
+        else if (expression instanceof IASTFieldReference)
+            visit((IASTFieldReference) expression);
+        else if (expression instanceof IASTFunctionCallExpression)
+            visit((IASTFunctionCallExpression) expression);
+        else if (expression instanceof IASTIdExpression)
+            visit((IASTIdExpression) expression);
+        else if (expression instanceof IASTLiteralExpression)
+            visit((IASTLiteralExpression) expression);
+        else if (expression instanceof IASTTypeIdExpression)
+            visit((IASTTypeIdExpression) expression);
+        else if (expression instanceof IASTTypeIdInitializerExpression)
+            visit((IASTTypeIdInitializerExpression) expression);
+        else if (expression instanceof IASTUnaryExpression)
+            visit((IASTUnaryExpression) expression);
+        else if (expression instanceof ICPPASTArraySubscriptExpression)
+            visit((ICPPASTArraySubscriptExpression) expression);
+        else if (expression instanceof ICPPASTBinaryExpression)
+            visit((ICPPASTBinaryExpression) expression);
+        else if (expression instanceof ICPPASTCastExpression)
+            visit((ICPPASTCastExpression) expression);
+        else if (expression instanceof ICPPASTDeleteExpression)
+            visit((ICPPASTDeleteExpression) expression);
+        else if (expression instanceof ICPPASTExpressionList)
+            visit((ICPPASTExpressionList) expression);
+        else if (expression instanceof ICPPASTFieldReference)
+            visit((ICPPASTFieldReference) expression);
+        else if (expression instanceof ICPPASTFunctionCallExpression)
+            visit((ICPPASTFunctionCallExpression) expression);
+        else if (expression instanceof ICPPASTLambdaExpression)
+            visit((ICPPASTLambdaExpression) expression);
+        else if (expression instanceof ICPPASTLiteralExpression)
+            visit((ICPPASTLiteralExpression) expression);
+        else if (expression instanceof ICPPASTNaryTypeIdExpression)
+            visit((ICPPASTNaryTypeIdExpression) expression);
+        else if (expression instanceof ICPPASTNewExpression)
+            visit((ICPPASTNewExpression) expression);
+        else if (expression instanceof ICPPASTPackExpansionExpression)
+            visit((ICPPASTPackExpansionExpression) expression);
+        else if (expression instanceof ICPPASTSimpleTypeConstructorExpression)
+            visit((ICPPASTSimpleTypeConstructorExpression) expression);
+        else if (expression instanceof ICPPASTTypeIdExpression)
+            visit((ICPPASTTypeIdExpression) expression);
+        else if (expression instanceof ICPPASTUnaryExpression)
+            visit((ICPPASTUnaryExpression) expression);
+        else if (expression instanceof IASTProblemExpression)
+            // Should not happen
+            visit((IASTProblemExpression) expression);
+        else if (expression instanceof CPPASTCompoundStatementExpression)
+            visit((CPPASTCompoundStatementExpression) expression);
+        else {
+            throw new RuntimeException("Expression: encountered non-implemented subtype "
+                    + expression.getClass().getName() + " at " + getSourceLocation(expression));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTArraySubscriptExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getArrayExpression().accept(this);
+        IConstructor arrayExpression = stack.pop();
+        expression.getArgument().accept(this);
+        IConstructor argument = stack.pop();
+
+        stack.push(builder.Expression_arraySubscriptExpression(arrayExpression, argument, loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTBinaryExpression expression) {
+        out("CPPBinaryExpression: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTCastExpression expression) {
+        out("CPPCastExpression: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTDeleteExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        expression.getOperand().accept(this);
+        if (expression.isGlobal()) {
+            if (expression.isVectored())
+                stack.push(builder.Expression_globalVectoredDelete(stack.pop(), loc, typ, isMacroExpansion));
+            else
+                stack.push(builder.Expression_globalDelete(stack.pop(), loc, typ, isMacroExpansion));
+        } else {
+            if (expression.isVectored())
+                stack.push(builder.Expression_vectoredDelete(stack.pop(), loc, typ, isMacroExpansion));
+            else
+                stack.push(builder.Expression_delete(stack.pop(), loc, typ, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTExpressionList expression) {
+        // has typ
+        out("CPPExpressionList: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTFieldReference expression) {
+        // has typ
+        out("CPPFieldReference: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTFunctionCallExpression expression) {
+        // has typ
+        out("CPPFunctionCallExpression: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTLambdaExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        ISourceLocation decl = br.UNKNOWN;
+        IConstructor typ = tr.resolveType(expression);
+        CaptureDefault captureDefault = expression.getCaptureDefault();
+
+        IListWriter captures = vf.listWriter();
+        Stream.of(expression.getCaptures()).forEach(it -> {
+            it.accept(this);
+            captures.append(stack.pop());
+        });
+
+        IConstructor declarator;
+        if (expression.getDeclarator() == null) {
+            ISourceLocation endOfCapture = getTokenSourceLocation(expression, "]");
+            declarator = builder.Declarator_missingDeclarator(
+                    vf.sourceLocation(endOfCapture, endOfCapture.getOffset() + 1, 0), decl, isMacroExpansion);
+        } else {
+            expression.getDeclarator().accept(this);
+            declarator = stack.pop();
+        }
+
+        expression.getBody().accept(this);
+        IConstructor body = stack.pop();
+
+        switch (captureDefault) {
+        case BY_COPY:
+            stack.push(builder.Expression_lambda(
+                    builder.Modifier_captDefByCopy(getTokenSourceLocation(expression, "="), isMacroExpansion),
+                    captures.done(), declarator, body, loc, typ, isMacroExpansion));
+            break;
+        case BY_REFERENCE:
+            stack.push(builder.Expression_lambda(
+                    builder.Modifier_captDefByReference(getTokenSourceLocation(expression, "&"), isMacroExpansion),
+                    captures.done(), declarator, body, loc, typ, isMacroExpansion));
+            break;
+        case UNSPECIFIED:
+            stack.push(builder.Expression_lambda(
+                    builder.Modifier_captDefUnspecified(vf.sourceLocation(loc, loc.getOffset(), 0), isMacroExpansion),
+                    captures.done(), declarator, body, loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("Unknown default capture type " + captureDefault + " encountered at "
+                    + getSourceLocation(expression) + ", exiting");
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTLiteralExpression expression) {
+        // This may never be reached
+        visit((IASTLiteralExpression) expression);
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTNaryTypeIdExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        IListWriter args = vf.listWriter();
+        Stream.of(expression.getOperands()).forEach(it -> {
+            it.accept(this);
+            args.append(stack.pop());
+        });
+        switch (expression.getOperator()) {
+        case __is_constructible:
+            stack.push(builder.Expression_isConstructable(args.done(), loc, typ, isMacroExpansion));
+            return PROCESS_ABORT;
+        case __is_trivially_constructible:
+            stack.push(builder.Expression_isTriviallyConstructable(args.done(), loc, typ, isMacroExpansion));
+            return PROCESS_ABORT;
+        default:
+            throw new RuntimeException("Operator " + expression.getOperator() + " unknown at " + loc + ", exiting");
+        }
+    }
+
+    public int visit(ICPPASTNewExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        // if (expression.isNewTypeId())
+        // err("WARNING: ICPPASTNewExpression \"" + expression.getRawSignature()
+        // + "\" has isNewTypeId=true");
+        // else
+        // err("WARNING: ICPPASTNewExpression \"" + expression.getRawSignature()
+        // + "\" has isNewTypeId=false");
+
+        expression.getTypeId().accept(this);
+        IConstructor typeId = stack.pop();
+
+        IASTInitializerClause[] _placementArguments = expression.getPlacementArguments();
+        IASTInitializer _initializer = expression.getInitializer();
+        if (_placementArguments != null) {
+            IListWriter placementArguments = vf.listWriter();
+            Stream.of(_placementArguments).forEach(it -> {
+                it.accept(this);
+                placementArguments.append(stack.pop());
+            });
+            if (_initializer == null) {
+                if (expression.isGlobal())
+                    stack.push(builder.Expression_globalNewWithArgs(placementArguments.done(), typeId, loc, typ,
+                            isMacroExpansion));
+                else
+                    stack.push(builder.Expression_newWithArgs(placementArguments.done(), typeId, loc, typ,
+                            isMacroExpansion));
+            } else {
+                _initializer.accept(this);
+                if (expression.isGlobal())
+                    stack.push(builder.Expression_globalNewWithArgs(placementArguments.done(), typeId, stack.pop(), loc,
+                            typ, isMacroExpansion));
+                else
+                    stack.push(builder.Expression_newWithArgs(placementArguments.done(), typeId, stack.pop(), loc, typ,
+                            isMacroExpansion));
+            }
+        } else if (_initializer == null) {
+            if (expression.isGlobal())
+                stack.push(builder.Expression_globalNew(typeId, loc, typ, isMacroExpansion));
+            else
+                stack.push(builder.Expression_new(typeId, loc, typ, isMacroExpansion));
+        } else {
+            _initializer.accept(this);
+            if (expression.isGlobal())
+                stack.push(builder.Expression_globalNew(typeId, stack.pop(), loc, typ, isMacroExpansion));
+            else
+                stack.push(builder.Expression_new(typeId, stack.pop(), loc, typ, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTPackExpansionExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        expression.getPattern().accept(this);
+        stack.push(builder.Expression_packExpansion(stack.pop(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTSimpleTypeConstructorExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getDeclSpecifier().accept(this);
+        IConstructor declSpecifier = stack.pop();
+        expression.getInitializer().accept(this);
+        IConstructor initializer = stack.pop();
+
+        stack.push(builder.Expression_simpleTypeConstructor(declSpecifier, initializer, loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTypeIdExpression expression) {
+        // has typ
+        out("CPPTypeIdExpression: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(ICPPASTUnaryExpression expression) {
+        out("CPPUnaryExpression: " + expression.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(expression));
+    }
+
+    public int visit(CPPASTCompoundStatementExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ;
+        try {
+            typ = tr.resolveType(expression);
+        } catch (Throwable t) {
+            err("CPPASTCompoundStatement couldn't get type at " + loc);
+            t.printStackTrace(err);
+            typ = builder.TypeSymbol_any();
+        }
+        expression.getCompoundStatement().accept(this);
+        stack.push(builder.Expression_compoundStatementExpression(stack.pop(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTArraySubscriptExpression expression) {
+        if (expression instanceof ICPPASTArraySubscriptExpression)
+            visit((ICPPASTArraySubscriptExpression) expression);
+        else
+            throw new RuntimeException("NYI at " + getSourceLocation(expression));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTBinaryExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getOperand1().accept(this);
+        IConstructor lhs = stack.pop();
+        expression.getInitOperand2().accept(this);
+        IConstructor rhs = stack.pop();
+
+        switch (expression.getOperator()) {
+        case IASTBinaryExpression.op_multiply:
+            stack.push(builder.Expression_multiply(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_divide:
+            stack.push(builder.Expression_divide(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_modulo:
+            stack.push(builder.Expression_modulo(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_plus:
+            stack.push(builder.Expression_plus(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_minus:
+            stack.push(builder.Expression_minus(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_shiftLeft:
+            stack.push(builder.Expression_shiftLeft(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_shiftRight:
+            stack.push(builder.Expression_shiftRight(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_lessThan:
+            stack.push(builder.Expression_lessThan(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_greaterThan:
+            stack.push(builder.Expression_greaterThan(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_lessEqual:
+            stack.push(builder.Expression_lessEqual(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_greaterEqual:
+            stack.push(builder.Expression_greaterEqual(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryAnd:
+            stack.push(builder.Expression_binaryAnd(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryXor:
+            stack.push(builder.Expression_binaryXor(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryOr:
+            stack.push(builder.Expression_binaryOr(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_logicalAnd:
+            stack.push(builder.Expression_logicalAnd(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_logicalOr:
+            stack.push(builder.Expression_logicalOr(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_assign:
+            stack.push(builder.Expression_assign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_multiplyAssign:
+            stack.push(builder.Expression_multiplyAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_divideAssign:
+            stack.push(builder.Expression_divideAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_moduloAssign:
+            stack.push(builder.Expression_moduloAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_plusAssign:
+            stack.push(builder.Expression_plusAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_minusAssign:
+            stack.push(builder.Expression_minusAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_shiftLeftAssign:
+            stack.push(builder.Expression_shiftLeftAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_shiftRightAssign:
+            stack.push(builder.Expression_shiftRightAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryAndAssign:
+            stack.push(builder.Expression_binaryAndAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryXorAssign:
+            stack.push(builder.Expression_binaryXorAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_binaryOrAssign:
+            stack.push(builder.Expression_binaryOrAssign(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_equals:
+            stack.push(builder.Expression_equals(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_notequals:
+            stack.push(builder.Expression_notEquals(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_pmdot:
+            stack.push(builder.Expression_pmDot(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_pmarrow:
+            stack.push(builder.Expression_pmArrow(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_max:
+            stack.push(builder.Expression_max(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_min:
+            stack.push(builder.Expression_min(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case IASTBinaryExpression.op_ellipses:
+            stack.push(builder.Expression_ellipses(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("Operator " + expression.getOperator() + " unknown at " + loc + ", exiting");
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTBinaryTypeIdExpression expression) {
+        // has typ
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getOperand1().accept(this);
+        IConstructor lhs = stack.pop();
+        expression.getOperand2().accept(this);
+        IConstructor rhs = stack.pop();
+
+        switch (expression.getOperator()) {
+        case __is_base_of:
+            stack.push(builder.Expression_isBaseOf(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        case __is_trivially_assignable:
+            stack.push(builder.Expression_isTriviallyAssignable(lhs, rhs, loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Unknown binary TypeId expression " + expression.getOperator().name() + " at " + loc);
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTCastExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getOperand().accept(this);
+        IConstructor operand = stack.pop();
+        expression.getTypeId().accept(this);
+        IConstructor type = stack.pop();
+
+        switch (expression.getOperator()) {
+        case ICPPASTCastExpression.op_cast:
+            stack.push(builder.Expression_cast(type, operand, loc, typ, isMacroExpansion));
+            break;
+        case ICPPASTCastExpression.op_dynamic_cast:
+            stack.push(builder.Expression_dynamicCast(type, operand, loc, typ, isMacroExpansion));
+            break;
+        case ICPPASTCastExpression.op_static_cast:
+            stack.push(builder.Expression_staticCast(type, operand, loc, typ, isMacroExpansion));
+            break;
+        case ICPPASTCastExpression.op_reinterpret_cast:
+            stack.push(builder.Expression_reinterpretCast(type, operand, loc, typ, isMacroExpansion));
+            break;
+        case ICPPASTCastExpression.op_const_cast:
+            stack.push(builder.Expression_constCast(type, operand, loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("Unknown cast type " + expression.getOperator() + " at " + loc);
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTConditionalExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getLogicalConditionExpression().accept(this);
+        IConstructor condition = stack.pop();
+        expression.getPositiveResultExpression().accept(this);
+        IConstructor positive = stack.pop();
+        expression.getNegativeResultExpression().accept(this);
+        IConstructor negative = stack.pop();
+
+        stack.push(builder.Expression_conditional(condition, positive, negative, loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTExpressionList expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        IListWriter expressions = vf.listWriter();
+        Stream.of(expression.getExpressions()).forEach(it -> {
+            it.accept(this);
+            expressions.append(stack.pop());
+        });
+        stack.push(builder.Expression_expressionList(expressions.done(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTFieldReference expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        if (expression instanceof ICPPASTFieldReference) {
+            // TODO: implement isTemplate
+            boolean isMacroExpansion = isMacroExpansion(expression);
+            ISourceLocation decl = br.resolveBinding(expression);
+            IConstructor typ = tr.resolveType(expression);
+
+            expression.getFieldOwner().accept(this);
+            IConstructor fieldOwner = stack.pop();
+            expression.getFieldName().accept(this);
+            IConstructor fieldName = stack.pop();
+
+            if (expression.isPointerDereference())
+                stack.push(builder.Expression_fieldReferencePointerDeref(fieldOwner, fieldName, loc, decl, typ,
+                        isMacroExpansion));
+            else
+                stack.push(builder.Expression_fieldReference(fieldOwner, fieldName, loc, decl, typ, isMacroExpansion));
+        } else
+            throw new RuntimeException("IASTFieldReference: NYI at " + loc);
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTFunctionCallExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getFunctionNameExpression().accept(this);
+        IConstructor functionName = stack.pop();
+
+        IListWriter arguments = vf.listWriter();
+        Stream.of(expression.getArguments()).forEach(it -> {
+            it.accept(this);
+            arguments.append(stack.pop());
+        });
+        stack.push(builder.Expression_functionCall(functionName, arguments.done(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTIdExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        ISourceLocation decl = br.resolveBinding(expression);
+        IConstructor typ = tr.resolveType(expression);
+        expression.getName().accept(this);
+        stack.push(builder.Expression_idExpression(stack.pop(), loc, decl, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTLiteralExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        String value = new String(expression.getValue());
+        switch (expression.getKind()) {
+        case IASTLiteralExpression.lk_integer_constant:
+            stack.push(builder.Expression_integerConstant(value, loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_float_constant:
+            stack.push(builder.Expression_floatConstant(value, loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_char_constant:
+            stack.push(builder.Expression_charConstant(value, loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_string_literal:
+            stack.push(builder.Expression_stringLiteral(value, loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_this:
+            stack.push(builder.Expression_this(loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_true:
+            stack.push(builder.Expression_true(loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_false:
+            stack.push(builder.Expression_false(loc, typ, isMacroExpansion));
+            break;
+        case IASTLiteralExpression.lk_nullptr:
+            stack.push(builder.Expression_nullptr(loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Encountered unknown literal kind " + expression.getKind() + " at " + loc + ". Exiting");
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTProblemExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IASTProblem problem = expression.getProblem();
+        if (doProblemLogging)
+            err("ProblemExpression " + expression.getRawSignature() + ":" + problem.getMessageWithLocation());
+        stack.push(builder.Expression_problemExpression(loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTTypeIdInitializerExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+        expression.getTypeId().accept(this);
+        IConstructor typeId = stack.pop();
+        expression.getInitializer().accept(this);
+        stack.push(builder.Expression_typeIdInitializerExpression(typeId, stack.pop(), loc, typ, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTTypeIdExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        expression.getTypeId().accept(this);
+        switch (expression.getOperator()) {
+        case IASTTypeIdExpression.op_sizeof:
+            stack.push(builder.Expression_sizeof(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_typeid:
+            stack.push(builder.Expression_typeid(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_alignof: // gnu-only?
+            stack.push(builder.Expression_alignOf(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_typeof:
+            stack.push(builder.Expression_typeof(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_nothrow_assign:
+            stack.push(builder.Expression_hasNothrowAssign(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_nothrow_copy:
+            stack.push(builder.Expression_hasNothrowCopy(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_nothrow_constructor:
+            stack.push(builder.Expression_hasNothrowConstructor(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_trivial_assign:
+            stack.push(builder.Expression_hasTrivialAssign(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_trivial_constructor:
+            stack.push(builder.Expression_hasTrivialConstructor(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_trivial_copy:
+            stack.push(builder.Expression_hasTrivialCopy(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_trivial_destructor:
+            stack.push(builder.Expression_hasTrivialDestructor(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_has_virtual_destructor:
+            stack.push(builder.Expression_hasVirtualDestructor(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_abstract:
+            stack.push(builder.Expression_isAbstract(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_class:
+            stack.push(builder.Expression_isClass(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_empty:
+            stack.push(builder.Expression_isEmpty(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_enum:
+            stack.push(builder.Expression_isEnum(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_pod:
+            stack.push(builder.Expression_isPod(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_polymorphic:
+            stack.push(builder.Expression_isPolymorphic(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_union:
+            stack.push(builder.Expression_isUnion(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_literal_type:
+            stack.push(builder.Expression_isLiteralType(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_standard_layout:
+            stack.push(builder.Expression_isStandardLayout(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_trivial:
+            stack.push(builder.Expression_isTrivial(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_sizeofParameterPack:
+            stack.push(builder.Expression_sizeofParameterPack(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_final:
+            stack.push(builder.Expression_isFinal(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        case IASTTypeIdExpression.op_is_trivially_copyable:
+            stack.push(builder.Expression_isTriviallyCopyable(stack.pop(), loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("ERROR: IASTTypeIdExpression called with unimplemented/unknown operator "
+                    + expression.getOperator() + " at " + loc);
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTUnaryExpression expression) {
+        ISourceLocation loc = getSourceLocation(expression);
+        boolean isMacroExpansion = isMacroExpansion(expression);
+        IConstructor typ = tr.resolveType(expression);
+
+        IConstructor operand = null;
+        if (expression.getOperand() != null) {
+            expression.getOperand().accept(this);
+            operand = stack.pop();
+        }
+
+        switch (expression.getOperator()) {
+        case IASTUnaryExpression.op_prefixIncr:
+            stack.push(builder.Expression_prefixIncr(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_prefixDecr:
+            stack.push(builder.Expression_prefixDecr(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_plus:
+            stack.push(builder.Expression_plus(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_minus:
+            stack.push(builder.Expression_minus(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_star:
+            stack.push(builder.Expression_star(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_amper:
+            stack.push(builder.Expression_amper(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_tilde:
+            stack.push(builder.Expression_tilde(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_not:
+            stack.push(builder.Expression_not(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_sizeof:
+            stack.push(builder.Expression_sizeof(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_postFixIncr:
+            stack.push(builder.Expression_postfixIncr(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_postFixDecr:
+            stack.push(builder.Expression_postfixDecr(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_bracketedPrimary:
+            stack.push(builder.Expression_bracketed(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_throw:
+            if (operand == null)
+                stack.push(builder.Expression_throw(loc, typ, isMacroExpansion));
+            else
+                stack.push(builder.Expression_throw(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_typeid:
+            stack.push(builder.Expression_typeid(operand, loc, typ, isMacroExpansion));
+            break;
+        // case IASTUnaryExpression.op_typeof: (14) typeOf is deprecated
+        case IASTUnaryExpression.op_alignOf:
+            stack.push(builder.Expression_alignOf(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_sizeofParameterPack:
+            stack.push(builder.Expression_sizeofParameterPack(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_noexcept:
+            stack.push(builder.Expression_noexcept(operand, loc, typ, isMacroExpansion));
+            break;
+        case IASTUnaryExpression.op_labelReference:
+            stack.push(builder.Expression_labelReference(operand, loc, typ, isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Unknown unary operator " + expression.getOperator() + " at " + loc + ". Exiting");
+        }
+
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTStatement statement) {
+        if (statement instanceof IASTAmbiguousStatement)
+            visit((IASTAmbiguousStatement) statement);
+        else if (statement instanceof IASTBreakStatement)
+            visit((IASTBreakStatement) statement);
+        else if (statement instanceof IASTCaseStatement)
+            visit((IASTCaseStatement) statement);
+        else if (statement instanceof IASTCompoundStatement)
+            visit((IASTCompoundStatement) statement);
+        else if (statement instanceof IASTContinueStatement)
+            visit((IASTContinueStatement) statement);
+        else if (statement instanceof IASTDeclarationStatement)
+            visit((IASTDeclarationStatement) statement);
+        else if (statement instanceof IASTDefaultStatement)
+            visit((IASTDefaultStatement) statement);
+        else if (statement instanceof IASTDoStatement)
+            visit((IASTDoStatement) statement);
+        else if (statement instanceof IASTExpressionStatement)
+            visit((IASTExpressionStatement) statement);
+        else if (statement instanceof IASTForStatement)
+            visit((IASTForStatement) statement);
+        else if (statement instanceof IASTGotoStatement)
+            visit((IASTGotoStatement) statement);
+        else if (statement instanceof IASTIfStatement)
+            visit((IASTIfStatement) statement);
+        else if (statement instanceof IASTLabelStatement)
+            visit((IASTLabelStatement) statement);
+        else if (statement instanceof IASTNullStatement)
+            visit((IASTNullStatement) statement);
+        else if (statement instanceof IASTReturnStatement)
+            visit((IASTReturnStatement) statement);
+        else if (statement instanceof IASTSwitchStatement)
+            visit((IASTSwitchStatement) statement);
+        else if (statement instanceof IASTWhileStatement)
+            visit((IASTWhileStatement) statement);
+        else if (statement instanceof ICPPASTCatchHandler)
+            visit((ICPPASTCatchHandler) statement);
+        else if (statement instanceof ICPPASTRangeBasedForStatement)
+            visit((ICPPASTRangeBasedForStatement) statement);
+        else if (statement instanceof ICPPASTTryBlockStatement)
+            visit((ICPPASTTryBlockStatement) statement);
+        else if (statement instanceof IGNUASTGotoStatement)
+            visit((IGNUASTGotoStatement) statement);
+        else if (statement instanceof IASTProblemStatement)
+            visit((IASTProblemStatement) statement);
+        else {
+            throw new RuntimeException("Statement: encountered non-implemented subtype "
+                    + statement.getClass().getName() + " at " + getSourceLocation(statement));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IGNUASTGotoStatement statement) {
+        // requires decl keyword parameter
+        err("IGNUAstGotoStatement: " + statement.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(statement));
+    }
+
+    public int visit(ICPPASTCatchHandler statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getCatchBody().accept(this);
+        IConstructor catchBody = stack.pop();
+
+        if (statement.isCatchAll())
+            stack.push(builder.Statement_catchAll(catchBody, attributes, loc, isMacroExpansion));
+        else {
+            statement.getDeclaration().accept(this);
+            stack.push(builder.Statement_catch(stack.pop(), catchBody, attributes, loc, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTRangeBasedForStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getDeclaration().accept(this);
+        IConstructor declaration = stack.pop();
+        statement.getInitializerClause().accept(this);
+        IConstructor initializerClause = stack.pop();
+        statement.getBody().accept(this);
+        IConstructor body = stack.pop();
+
+        stack.push(builder.Statement_rangeBasedFor(declaration, initializerClause, body, attributes, loc,
+                isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(ICPPASTTryBlockStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getTryBody().accept(this);
+        IConstructor tryBody = stack.pop();
+
+        IListWriter catchHandlers = vf.listWriter();
+        Stream.of(statement.getCatchHandlers()).forEach(it -> {
+            it.accept(this);
+            catchHandlers.append(stack.pop());
+        });
+
+        stack.push(builder.Statement_tryBlock(tryBody, catchHandlers.done(), attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTAmbiguousStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        out("visit(IASTAmbiguousStatement) " + loc);
+        out(statement.getRawSignature());
+        IListWriter statements = vf.listWriter();
+        prefix += 4;
+        Stream.of(statement.getStatements()).forEach(it -> {
+            out("Statement " + it.getClass().getSimpleName() + ": " + it.getRawSignature());
+            it.accept(this);
+            statements.append(stack.pop());
+        });
+        prefix -= 4;
+        throw new RuntimeException("Encountered Ambiguous statement at " + loc);
+    }
+
+    public int visit(IASTBreakStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        stack.push(builder.Statement_break(attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTCaseStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        statement.getExpression().accept(this);
+        IConstructor expression = stack.pop();
+        stack.push(builder.Statement_case(expression, attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTCompoundStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        IListWriter statements = vf.listWriter();
+        Stream.of(statement.getStatements()).forEach(it -> {
+            it.accept(this);
+            statements.append(stack.pop());
+        });
+        stack.push(builder.Statement_compoundStatement(statements.done(), attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTContinueStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        stack.push(builder.Statement_continue(attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTDeclarationStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        statement.getDeclaration().accept(this);
+        stack.push(builder.Statement_declarationStatement(stack.pop(), attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTDefaultStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        stack.push(builder.Statement_defaultCase(attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTDoStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getBody().accept(this);
+        IConstructor body = stack.pop();
+        statement.getCondition().accept(this);
+        IConstructor condition = stack.pop();
+        stack.push(builder.Statement_do(body, condition, attributes, loc, isMacroExpansion));
+
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTExpressionStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        statement.getExpression().accept(this);
+        stack.push(builder.Statement_expressionStatement(stack.pop(), attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTForStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        IASTStatement _initializer = statement.getInitializerStatement();
+        IConstructor initializer = null;
+        if (_initializer != null) {
+            _initializer.accept(this);
+            initializer = stack.pop();
+        }
+
+        IASTExpression _condition = statement.getConditionExpression();
+        IConstructor condition;
+        if (_condition == null) {
+            ISourceLocation initializerLoc = (ISourceLocation) initializer.asWithKeywordParameters()
+                    .getParameter("src");
+            condition = builder.Expression_empty(
+                    vf.sourceLocation(initializerLoc, initializerLoc.getOffset() + initializerLoc.getLength(), 0),
+                    isMacroExpansion);
+        } else {
+            _condition.accept(this);
+            condition = stack.pop();
+        }
+
+        IASTExpression _iteration = statement.getIterationExpression();
+        IConstructor iteration;
+        if (_iteration == null) {
+            ISourceLocation conditionLoc = (ISourceLocation) condition.asWithKeywordParameters().getParameter("src");
+            iteration = builder.Expression_empty(
+                    vf.sourceLocation(conditionLoc, conditionLoc.getOffset() + conditionLoc.getLength(), 0),
+                    isMacroExpansion);
+        } else {
+            _iteration.accept(this);
+            iteration = stack.pop();
+        }
+
+        statement.getBody().accept(this);
+        IConstructor body = stack.pop();
+
+        if (statement instanceof ICPPASTForStatement) {
+            IASTDeclaration _conditionDeclaration = ((ICPPASTForStatement) statement).getConditionDeclaration();
+            if (_conditionDeclaration != null) {
+                _conditionDeclaration.accept(this);
+                stack.push(builder.Statement_forWithDecl(initializer, stack.pop(), iteration, body, attributes, loc,
+                        isMacroExpansion));
+                return PROCESS_ABORT;
+            }
+        }
+        stack.push(builder.Statement_for(initializer, condition, iteration, body, attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTGotoStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        ISourceLocation decl = br.resolveBinding(statement);
+        IList attributes = getAttributes(statement);
+        statement.getName().accept(this);
+        stack.push(builder.Statement_goto(stack.pop(), attributes, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTIfStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getThenClause().accept(this);
+        IConstructor thenClause = stack.pop();
+
+        IConstructor elseClause = null;
+        if (statement.getElseClause() != null) {
+            statement.getElseClause().accept(this);
+            elseClause = stack.pop();
+        }
+
+        if (statement.getConditionExpression() == null && statement instanceof ICPPASTIfStatement) {
+            ((ICPPASTIfStatement) statement).getConditionDeclaration().accept(this);
+            if (elseClause == null) {
+                stack.push(builder.Statement_ifWithDecl(stack.pop(), thenClause, attributes, loc, isMacroExpansion));
+            } else {
+                stack.push(builder.Statement_ifWithDecl(stack.pop(), thenClause, elseClause, attributes, loc,
+                        isMacroExpansion));
+            }
+        } else {
+            statement.getConditionExpression().accept(this);
+            if (elseClause == null) {
+                stack.push(builder.Statement_if(stack.pop(), thenClause, attributes, loc, isMacroExpansion));
+            } else {
+                stack.push(
+                        builder.Statement_if(stack.pop(), thenClause, elseClause, attributes, loc, isMacroExpansion));
+            }
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTLabelStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        ISourceLocation decl = br.resolveBinding(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getName().accept(this);
+        IConstructor name = stack.pop();
+        statement.getNestedStatement().accept(this);
+        IConstructor nestedStatement = stack.pop();
+
+        stack.push(builder.Statement_label(name, nestedStatement, attributes, loc, decl, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTNullStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        stack.push(builder.Statement_nullStatement(attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTProblemStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        if (doProblemLogging) {
+            err("IASTProblemStatement:");
+            prefix += 4;
+            err(statement.getProblem().getMessageWithLocation());
+            err("" + statement.getProblem().getID());
+            err(statement.getRawSignature());
+            prefix -= 4;
+        }
+        stack.push(builder.Statement_problem(statement.getRawSignature(), loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTReturnStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+        IASTExpression returnValue = statement.getReturnValue();
+        IASTInitializerClause returnArgument = statement.getReturnArgument();
+        if (returnValue == null && returnArgument == null)
+            stack.push(builder.Statement_return(attributes, loc, isMacroExpansion));
+        else if (returnValue != null) {
+            returnValue.accept(this);
+            stack.push(builder.Statement_return(stack.pop(), attributes, loc, isMacroExpansion));
+        } else {
+            returnArgument.accept(this);
+            // Note: InitializerClause is currently mapped on Expression
+            stack.push(builder.Statement_return(stack.pop(), attributes, loc, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTSwitchStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getBody().accept(this);
+        IConstructor body = stack.pop();
+
+        IASTExpression _controller = statement.getControllerExpression();
+        if (_controller == null && statement instanceof ICPPASTSwitchStatement) {
+            ((ICPPASTSwitchStatement) statement).getControllerDeclaration().accept(this);
+            stack.push(builder.Statement_switchWithDecl(stack.pop(), body, attributes, loc, isMacroExpansion));
+            return PROCESS_ABORT;
+        }
+
+        _controller.accept(this);
+        stack.push(builder.Statement_switch(stack.pop(), body, attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    public int visit(IASTWhileStatement statement) {
+        ISourceLocation loc = getSourceLocation(statement);
+        boolean isMacroExpansion = isMacroExpansion(statement);
+        IList attributes = getAttributes(statement);
+
+        statement.getBody().accept(this);
+        IConstructor body = stack.pop();
+
+        IASTExpression _condition = statement.getCondition();
+        if (_condition == null && statement instanceof ICPPASTWhileStatement) {
+            ((ICPPASTWhileStatement) statement).getConditionDeclaration().accept(this);
+            stack.push(builder.Statement_whileWithDecl(stack.pop(), body, attributes, loc, isMacroExpansion));
+            return PROCESS_ABORT;
+        }
+        _condition.accept(this);
+        stack.push(builder.Statement_while(stack.pop(), body, attributes, loc, isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTTypeId typeId) {
+        ISourceLocation loc = getSourceLocation(typeId);
+        boolean isMacroExpansion = isMacroExpansion(typeId);
+        if (typeId instanceof IASTProblemTypeId) {
+            if (typeId.getRawSignature().equals("...") || typeId.getRawSignature().contains("_THROW1("))
+                stack.push(builder.Expression_typeId(
+                        builder.DeclSpecifier_msThrowEllipsis(loc, vf.sourceLocation("unknown:///"), false), loc,
+                        isMacroExpansion));
+            else {
+                out("ProblemTypeId " + typeId.getClass().getSimpleName() + ": " + typeId.getRawSignature());
+                throw new RuntimeException("IASTProblemTypeId encountered at " + loc + "! "
+                        + ((IASTProblemTypeId) typeId).getProblem().getMessageWithLocation());
+            }
+        } else {
+            typeId.getDeclSpecifier().accept(this);
+            IConstructor declSpecifier = stack.pop();
+            typeId.getAbstractDeclarator().accept(this);
+            IConstructor abstractDeclarator = stack.pop();
+            if (abstractDeclarator.has("name")) {// TODO: properly fix
+                ISourceLocation declaratorLoc = getSourceLocation(typeId.getAbstractDeclarator());
+                abstractDeclarator = abstractDeclarator.set("name",
+                        builder.Name_abstractEmptyName(declaratorLoc, false));
+                abstractDeclarator = abstractDeclarator.asWithKeywordParameters().unsetParameter("decl");
+            }
+            stack.push(builder.Expression_typeId(declSpecifier, abstractDeclarator, loc, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTEnumerator enumerator) {
+        ISourceLocation loc = getSourceLocation(enumerator);
+        boolean isMacroExpansion = isMacroExpansion(enumerator);
+        ISourceLocation decl = br.resolveBinding(enumerator);
+
+        enumerator.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        IASTExpression value = enumerator.getValue();
+        if (value == null)
+            stack.push(builder.Declaration_enumerator(name, loc, decl, isMacroExpansion));
+        else {
+            value.accept(this);
+            stack.push(builder.Declaration_enumerator(name, stack.pop(), loc, decl, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(IASTProblem problem) {
+        err("Problem: " + problem.getMessage());
+        throw new RuntimeException("NYI at " + getSourceLocation(problem));
+    }
+
+    @Override
+    public int visit(ICPPASTBaseSpecifier baseSpecifier) {
+        ISourceLocation loc = getSourceLocation(baseSpecifier);
+        boolean isMacroExpansion = isMacroExpansion(baseSpecifier);
+        ISourceLocation decl = br.resolveBinding(baseSpecifier);
+        IConstructor typ = tr.resolveType(baseSpecifier);
+
+        IListWriter modifiers = vf.listWriter();
+        switch (baseSpecifier.getVisibility()) {
+        case ICPPASTBaseSpecifier.v_public:
+            modifiers
+                    .append(builder.Modifier_public(getTokenSourceLocation(baseSpecifier, "public"), isMacroExpansion));
+            break;
+        case ICPPASTBaseSpecifier.v_protected:
+            modifiers.append(
+                    builder.Modifier_protected(getTokenSourceLocation(baseSpecifier, "protected"), isMacroExpansion));
+            break;
+        case ICPPASTBaseSpecifier.v_private:
+            modifiers.append(
+                    builder.Modifier_private(getTokenSourceLocation(baseSpecifier, "private"), isMacroExpansion));
+            break;
+        case 0:
+            modifiers.append(builder.Modifier_unspecifiedInheritance(vf.sourceLocation(loc, loc.getOffset(), 0),
+                    isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException(
+                    "Unknown BaseSpecifier visibility code " + baseSpecifier.getVisibility() + " at " + loc);
+        }
+        if (baseSpecifier.isVirtual())
+            modifiers.append(
+                    builder.Modifier_virtual(getTokenSourceLocation(baseSpecifier, "virtual"), isMacroExpansion));
+
+        ICPPASTNameSpecifier nameSpecifier = baseSpecifier.getNameSpecifier();
+        if (nameSpecifier == null)
+            stack.push(builder.Declaration_baseSpecifier(modifiers.done(), loc, decl, isMacroExpansion));
+        else {
+            nameSpecifier.accept(this);
+            stack.push(builder.Declaration_baseSpecifier(modifiers.done(), stack.pop(), loc, decl, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICPPASTNamespaceDefinition namespaceDefinition) {
+        ISourceLocation loc = getSourceLocation(namespaceDefinition);
+        boolean isMacroExpansion = isMacroExpansion(namespaceDefinition);
+        ISourceLocation decl = br.resolveBinding(namespaceDefinition);
+        IList attributes = getAttributes(namespaceDefinition);
+
+        namespaceDefinition.getName().accept(this);
+        IConstructor name = stack.pop();
+
+        IListWriter declarations = vf.listWriter();
+        Stream.of(namespaceDefinition.getDeclarations()).forEach(it -> {
+            it.accept(this);
+            declarations.append(stack.pop());
+        });
+
+        if (namespaceDefinition.isInline())
+            stack.push(builder.Declaration_namespaceDefinitionInline(name, declarations.done(), attributes, loc, decl,
+                    isMacroExpansion));
+        else
+            stack.push(builder.Declaration_namespaceDefinition(name, declarations.done(), attributes, loc, decl,
+                    isMacroExpansion));
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICPPASTTemplateParameter templateParameter) {
+        ISourceLocation loc = getSourceLocation(templateParameter);
+        boolean isMacroExpansion = isMacroExpansion(templateParameter);
+        // boolean isParameterPack = templateParameter.isParameterPack();
+        // if (isParameterPack)
+        // err("WARNING: ICPPASTTemplateParameter has isParameterPack=true,
+        // unimplemented");
+        if (templateParameter instanceof ICPPASTSimpleTypeTemplateParameter) {
+            ISourceLocation decl = br.resolveBinding((ICPPASTSimpleTypeTemplateParameter) templateParameter);
+            IConstructor typ = tr.resolveType(templateParameter);
+
+            ICPPASTSimpleTypeTemplateParameter parameter = (ICPPASTSimpleTypeTemplateParameter) templateParameter;
+            parameter.getName().accept(this);
+            IConstructor name = stack.pop();
+
+            if (parameter.getDefaultType() != null) {
+                parameter.getDefaultType().accept(this);
+                switch (parameter.getParameterType()) {
+                case ICPPASTSimpleTypeTemplateParameter.st_class:
+                    stack.push(builder.Declaration_sttClass(name, stack.pop(), loc, decl, isMacroExpansion));
+                    break;
+                case ICPPASTSimpleTypeTemplateParameter.st_typename:
+                    stack.push(builder.Declaration_sttTypename(name, stack.pop(), loc, decl, isMacroExpansion));
+                    break;
+                default:
+                    throw new RuntimeException("ICPPASTTemplateParameter encountered non-implemented parameter type "
+                            + parameter.getParameterType() + " at " + loc);
+                }
+            } else {
+                switch (parameter.getParameterType()) {
+                case ICPPASTSimpleTypeTemplateParameter.st_class:
+                    stack.push(builder.Declaration_sttClass(name, loc, decl, isMacroExpansion));
+                    break;
+                case ICPPASTSimpleTypeTemplateParameter.st_typename:
+                    stack.push(builder.Declaration_sttTypename(name, loc, decl, isMacroExpansion));
+                    break;
+                default:
+                    throw new RuntimeException("ICPPASTTemplateParameter encountered non-implemented parameter type "
+                            + parameter.getParameterType() + " at " + loc);
+                }
+            }
+        } else if (templateParameter instanceof ICPPASTTemplatedTypeTemplateParameter) {
+            ISourceLocation decl = br.resolveBinding((ICPPASTTemplatedTypeTemplateParameter) templateParameter);
+            IListWriter templateParameters = vf.listWriter();
+            Stream.of(((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getTemplateParameters())
+                    .forEach(it -> {
+                        it.accept(this);
+                        templateParameters.append(stack.pop());
+                    });
+            ((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getName().accept(this);
+            IConstructor name = stack.pop();
+            IASTExpression defaultValue = ((ICPPASTTemplatedTypeTemplateParameter) templateParameter).getDefaultValue();
+            if (defaultValue == null) {
+                stack.push(
+                        builder.Declaration_tttParameter(templateParameters.done(), name, loc, decl, isMacroExpansion));
+            } else {
+                defaultValue.accept(this);
+                stack.push(builder.Declaration_tttParameterWithDefault(templateParameters.done(), name, stack.pop(),
+                        loc, decl, isMacroExpansion));
+            }
+        } else
+            throw new RuntimeException("ICPPASTTemplateParameter encountered unknown subtype "
+                    + templateParameter.getClass().getName() + " at " + loc + ". Exiting");
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICPPASTCapture capture) {
+        // TODO: check isPackExpansion
+        ISourceLocation loc = getSourceLocation(capture);
+        boolean isMacroExpansion = isMacroExpansion(capture);
+        if (capture.capturesThisPointer())
+            stack.push(builder.Expression_captureThisPtr(loc, isMacroExpansion));
+        else {
+            ISourceLocation decl = br.resolveBinding(capture);
+            capture.getIdentifier().accept(this);
+            if (capture.isByReference())
+                stack.push(builder.Expression_captureByRef(stack.pop(), loc, decl, isMacroExpansion));
+            else
+                stack.push(builder.Expression_capture(stack.pop(), loc, decl, isMacroExpansion));
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICASTDesignator designator) {
+        err("Designator: " + designator.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(designator));
+    }
+
+    @Override
+    public int visit(ICPPASTDesignator designator) {
+        ISourceLocation loc = getSourceLocation(designator);
+        boolean isMacroExpansion = isMacroExpansion(designator);
+        if (designator instanceof ICPPASTArrayDesignator) {
+            ((ICPPASTArrayDesignator) designator).getSubscriptExpression().accept(this);
+            stack.push(builder.Expression_arrayDesignator(stack.pop(), loc, isMacroExpansion));
+        } else if (designator instanceof ICPPASTFieldDesignator) {
+            ((ICPPASTFieldDesignator) designator).getName().accept(this);
+            stack.push(builder.Expression_fieldDesignator(stack.pop(), loc, isMacroExpansion));
+        } else if (designator instanceof IGPPASTArrayRangeDesignator) {
+            ((IGPPASTArrayRangeDesignator) designator).getRangeFloor().accept(this);
+            IConstructor rangeFloor = stack.pop();
+            ((IGPPASTArrayRangeDesignator) designator).getRangeCeiling().accept(this);
+            IConstructor rangeCeiling = stack.pop();
+            stack.push(builder.Expression_arrayRangeDesignator(rangeFloor, rangeCeiling, loc, isMacroExpansion));
+        } else
+            throw new RuntimeException("ICPPASTDesignator encountered unknown subclass at " + loc + ", exiting");
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICPPASTVirtSpecifier virtSpecifier) {
+        ISourceLocation loc = getSourceLocation(virtSpecifier);
+        boolean isMacroExpansion = isMacroExpansion(virtSpecifier);
+        switch (virtSpecifier.getKind()) {
+        case Final:
+            stack.push(builder.Declaration_virtSpecifier(
+                    builder.Modifier_final(getTokenSourceLocation(virtSpecifier, "final"), isMacroExpansion), loc,
+                    isMacroExpansion));
+            break;
+        case Override:
+            stack.push(builder.Declaration_virtSpecifier(
+                    builder.Modifier_override(getTokenSourceLocation(virtSpecifier, "override"), isMacroExpansion), loc,
+                    isMacroExpansion));
+            break;
+        default:
+            throw new RuntimeException("ICPPASTVirtSpecifier encountered unknown SpecifierKind "
+                    + virtSpecifier.getKind().name() + " at " + loc);
+        }
+        return PROCESS_ABORT;
+    }
+
+    @Override
+    public int visit(ICPPASTClassVirtSpecifier classVirtSpecifier) {
+        err("ClassVirtSpecifier: " + classVirtSpecifier.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(classVirtSpecifier));
+    }
+
+    @Override
+    public int visit(ICPPASTDecltypeSpecifier decltypeSpecifier) {
+        // has typ
+        err("DecltypeSpecifier: " + decltypeSpecifier.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(decltypeSpecifier));
+    }
+
+    @Override
+    public int visit(ASTAmbiguousNode astAmbiguousNode) {
+        err("AstAmbiguousNode: " + astAmbiguousNode.getRawSignature());
+        throw new RuntimeException("NYI at " + getSourceLocation(astAmbiguousNode));
+    }
 
 }


### PR DESCRIPTION
- different pom parent without eclipse neon
- editing files to move to java11 and the corresponding API changes in Rascal 0.23.x
- removed unnecessary @reflect from functions
