### PR TITLE
Avoid removal of virtual method calls from call graph when applying method overrides

### DIFF
--- a/src/lang/cpp/M3.rsc
+++ b/src/lang/cpp/M3.rsc
@@ -291,10 +291,16 @@ M3 composeCppM3(loc id, set[M3] models) {
   return comp;
 }
 
-@synopsis{fills out the call graph by adding the tuples for possible actual methods and constructors, and removing the corresponding calls to virtual methods and constructors.}
+@synopsis{Fills out the call graph by adding the tuples for possible actual methods and constructors.}
+@pitfalls{
+A previous version of this function would remove the virtual method calls from the call graph.
+Virtual methods in C++ can, however, have an implementation (if they do not, they are called pure virtual functions).
+As a consequence, they can also be called and must remain in the call graph.
+
+At the moment, we overapproximate and remove no scheme, even though some might be able to be removed.
+}
 rel[loc caller, loc callee] closeOverriddenVirtualCalls(M3 comp) {
-  return comp.callGraph 
-    + comp.callGraph o comp.methodOverrides // add the overridden definitions
-    - rangeR(comp.callGraph, comp.methodOverrides<0>); // remove the virtual intermediates
+  return comp.callGraph
+    + comp.callGraph o comp.methodOverrides; // add the overridden definitions
 }
 


### PR DESCRIPTION
See #83 .
We are currently moving in the other extreme, because there are other schemes that we might be able to remove safely.

Looking at my project, I see the following override relations:
```
<"cpp+functionSet","cpp+method">,
<"cpp+destructor","cpp+destructor">,
<"cpp+destructor","cpp+functionSpecialization">,
<"cpp+method","cpp+method">,
<"cpp+method","cpp+functionSpecialization">,
<"cpp+functionSpecialization","cpp+destructor">,
<"cpp+functionSpecialization","cpp+method">,
<"cpp+functionSpecialization","cpp+functionSpecialization">,
<"cpp+new","cpp+functionSpecialization">,
<"cpp+new","cpp+constructor">,
<"cpp+new","cpp+functionInstance">,
<"cpp+new","problem">
```
(left is overwritten by right).

Without too much research, it looks like most of them should stay in the call graph even after expanding it.
The first one might be removable (see [here](https://github.com/eclipse-cdt/cdt/blob/main/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPFunctionSet.java#L33), functionSet seems to be an intermediate representation).

@jurgenvinju also pointed out that we might want to look at individual virtual methods and filter out the ones that do not have an implementation.